### PR TITLE
Require admin role for `setTransferFeeRatio`

### DIFF
--- a/contracts/test/TestERC20.sol
+++ b/contracts/test/TestERC20.sol
@@ -26,6 +26,7 @@ contract TestERC20 is ERC20PresetMinterPauserUpgradeable {
     }
 
     function setTransferFeeRatio(uint256 ratio) external {
+        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "TestERC20: must have admin role to mint");
         _transferFeeRatio = ratio;
     }
 


### PR DESCRIPTION
Someone changed the transfer fee to a very large number making the token unusable: https://kovan-optimistic.etherscan.io/tx/3742115