### PR TITLE
feat: rename markTwap to marketTwap and remove redundant import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `AccountBalance.getMarkPrice(address)` to return the mark price of given market.
 - Add `ClearingHouseConfig.getMarkPriceConfig()` to return marketTwapInterval and premiumInterval used for mark price calculations.
+- Add `Exchange.getSqrtMarketTwapX96()` to return market twap.
 
 ### Changed
 - Move events in ClearingHouseConfig to IClearingHouseConfigEvent in IClearingHouseConfig.sol
 
 ### Deprecated
 - BackstopLiquidityProvider from ClearingHouseConfig & IClearingHouseConfig and comments added to ClearingHouseConfigStorage
+- `Exchange.getSqrtMarkTwapX96(address baseToken, uint32 twapInterval)` will be deprecated at later releases. Suggest to use `Exchange.getSqrtMarketTwapX96()` instead.
 
 ## [2.2.3] - 2022-10-24
 ### Changed

--- a/contracts/AccountBalance.sol
+++ b/contracts/AccountBalance.sol
@@ -542,7 +542,7 @@ contract AccountBalance is IAccountBalance, BlockContext, ClearingHouseCallee, A
         address marketRegistry = UniswapV3CallbackBridge(_orderBook).getMarketRegistry();
         address pool = IMarketRegistry(marketRegistry).getPool(baseToken);
         return
-            UniswapV3Broker.getSqrtMarkTwapX96(pool, twapInterval).formatSqrtPriceX96ToPriceX96().formatX96ToX10_18();
+            UniswapV3Broker.getSqrtMarketTwapX96(pool, twapInterval).formatSqrtPriceX96ToPriceX96().formatX96ToX10_18();
     }
 
     function _getIndexPrice(address baseToken, uint32 twapInterval) internal view returns (uint256) {

--- a/contracts/ClearingHouse.sol
+++ b/contracts/ClearingHouse.sol
@@ -1113,7 +1113,7 @@ contract ClearingHouse is
     }
 
     function _getSqrtMarketTwapX96(address baseToken) internal view returns (uint160) {
-        return IExchange(_exchange).getSqrtMarkTwapX96(baseToken, 0);
+        return IExchange(_exchange).getSqrtMarketTwapX96(baseToken, 0);
     }
 
     function _getMarginRequirementForLiquidation(address trader) internal view returns (int256) {

--- a/contracts/ClearingHouse.sol
+++ b/contracts/ClearingHouse.sol
@@ -22,7 +22,6 @@ import { IERC20Metadata } from "./interface/IERC20Metadata.sol";
 import { IVault } from "./interface/IVault.sol";
 import { IExchange } from "./interface/IExchange.sol";
 import { IOrderBook } from "./interface/IOrderBook.sol";
-import { IIndexPrice } from "./interface/IIndexPrice.sol";
 import { IBaseToken } from "./interface/IBaseToken.sol";
 import { IClearingHouseConfig } from "./interface/IClearingHouseConfig.sol";
 import { IAccountBalance } from "./interface/IAccountBalance.sol";
@@ -264,7 +263,7 @@ contract ClearingHouse is
                     removedOpenNotional
                 );
 
-            uint256 sqrtPrice = _getSqrtMarkX96(params.baseToken);
+            uint256 sqrtPrice = _getSqrtMarketTwapX96(params.baseToken);
             _emitPositionChanged(
                 trader,
                 params.baseToken,
@@ -790,7 +789,7 @@ contract ClearingHouse is
             takerFee, // fee
             _getTakerOpenNotional(trader, baseToken), // openNotional
             realizedPnl,
-            _getSqrtMarkX96(baseToken) // sqrtPriceAfterX96: no swap, so market price didn't change
+            _getSqrtMarketTwapX96(baseToken) // sqrtPriceAfterX96: no swap, so market price didn't change
         );
     }
 
@@ -1113,8 +1112,8 @@ contract ClearingHouse is
         return IVault(_vault).getFreeCollateralByRatio(trader, ratio);
     }
 
-    function _getSqrtMarkX96(address baseToken) internal view returns (uint160) {
-        return IExchange(_exchange).getSqrtMarkTwapX96(baseToken, 0);
+    function _getSqrtMarketTwapX96(address baseToken) internal view returns (uint160) {
+        return IExchange(_exchange).getSqrtMarketTwapX96(baseToken, 0);
     }
 
     function _getMarginRequirementForLiquidation(address trader) internal view returns (int256) {

--- a/contracts/ClearingHouse.sol
+++ b/contracts/ClearingHouse.sol
@@ -1113,7 +1113,7 @@ contract ClearingHouse is
     }
 
     function _getSqrtMarketTwapX96(address baseToken) internal view returns (uint160) {
-        return IExchange(_exchange).getSqrtMarketTwapX96(baseToken, 0);
+        return IExchange(_exchange).getSqrtMarkTwapX96(baseToken, 0);
     }
 
     function _getMarginRequirementForLiquidation(address trader) internal view returns (int256) {

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -346,11 +346,22 @@ contract Exchange is
 
     /// @inheritdoc IExchange
     function isOverPriceSpread(address baseToken) external view override returns (bool) {
-        uint256 markPrice = getSqrtMarkTwapX96(baseToken, 0).formatSqrtPriceX96ToPriceX96().formatX96ToX10_18();
+        uint256 marketPrice = _getSqrtMarketTwapX96(baseToken, 0).formatSqrtPriceX96ToPriceX96().formatX96ToX10_18();
         uint256 indexTwap =
             IIndexPrice(baseToken).getIndexPrice(IClearingHouseConfig(_clearingHouseConfig).getTwapInterval());
-        uint256 spread = markPrice > indexTwap ? markPrice.sub(indexTwap) : indexTwap.sub(markPrice);
+        uint256 spread = marketPrice > indexTwap ? marketPrice.sub(indexTwap) : indexTwap.sub(marketPrice);
         return spread > PerpMath.mulRatio(indexTwap, _MAX_PRICE_SPREAD_RATIO);
+    }
+
+    /// @inheritdoc IExchange
+    // Deprecated function, will be removed in the next release
+    function getSqrtMarkTwapX96(address baseToken, uint32 twapInterval) external view override returns (uint160) {
+        return _getSqrtMarketTwapX96(baseToken, twapInterval);
+    }
+
+    /// @inheritdoc IExchange
+    function getSqrtMarketTwapX96(address baseToken, uint32 twapInterval) external view override returns (uint160) {
+        return _getSqrtMarketTwapX96(baseToken, twapInterval);
     }
 
     //
@@ -371,11 +382,6 @@ contract Exchange is
                 fundingGrowthGlobal,
                 liquidityCoefficientInFundingPayment
             );
-    }
-
-    /// @inheritdoc IExchange
-    function getSqrtMarkTwapX96(address baseToken, uint32 twapInterval) public view override returns (uint160) {
-        return UniswapV3Broker.getSqrtMarkTwapX96(IMarketRegistry(_marketRegistry).getPool(baseToken), twapInterval);
     }
 
     //
@@ -570,6 +576,10 @@ contract Exchange is
     // INTERNAL VIEW
     //
 
+    function _getSqrtMarketTwapX96(address baseToken, uint32 twapInterval) internal view returns (uint160) {
+        return UniswapV3Broker.getSqrtMarketTwapX96(IMarketRegistry(_marketRegistry).getPool(baseToken), twapInterval);
+    }
+
     function _isOverPriceLimit(address baseToken) internal view returns (bool) {
         int24 tick = _getTick(baseToken);
         return _isOverPriceLimitWithTick(baseToken, tick);
@@ -617,7 +627,7 @@ contract Exchange is
 
         uint256 markTwapX96;
         if (marketOpen) {
-            markTwapX96 = getSqrtMarkTwapX96(baseToken, twapInterval).formatSqrtPriceX96ToPriceX96();
+            markTwapX96 = _getSqrtMarketTwapX96(baseToken, twapInterval).formatSqrtPriceX96ToPriceX96();
             indexTwap = IIndexPrice(baseToken).getIndexPrice(twapInterval);
         } else {
             // if a market is paused/closed, we use the last known index price which is getPausedIndexPrice
@@ -628,7 +638,7 @@ contract Exchange is
             // timestamp is pausedTime when the market is not open
             uint32 secondsAgo = _blockTimestamp().sub(timestamp).toUint32();
             markTwapX96 = UniswapV3Broker
-                .getSqrtMarkTwapX96From(IMarketRegistry(_marketRegistry).getPool(baseToken), secondsAgo, twapInterval)
+                .getSqrtMarketTwapX96From(IMarketRegistry(_marketRegistry).getPool(baseToken), secondsAgo, twapInterval)
                 .formatSqrtPriceX96ToPriceX96();
             indexTwap = IBaseToken(baseToken).getPausedIndexPrice();
         }
@@ -652,7 +662,7 @@ contract Exchange is
             // log(1e9 * 2^96 * (3600 * 24 * 365) * 2^96) / log(2) = 246.8078491997 < 255
             // twPremiumDivBySqrtPrice += deltaTwPremium / getSqrtMarkTwap(baseToken)
             fundingGrowthGlobal.twPremiumDivBySqrtPriceX96 = lastFundingGrowthGlobal.twPremiumDivBySqrtPriceX96.add(
-                PerpMath.mulDiv(deltaTwPremiumX96, PerpFixedPoint96._IQ96, getSqrtMarkTwapX96(baseToken, 0))
+                PerpMath.mulDiv(deltaTwPremiumX96, PerpFixedPoint96._IQ96, _getSqrtMarketTwapX96(baseToken, 0))
             );
         }
 

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -354,7 +354,13 @@ contract Exchange is
     }
 
     /// @inheritdoc IExchange
+    // Deprecated function, will be removed in the next release
     function getSqrtMarkTwapX96(address baseToken, uint32 twapInterval) external view override returns (uint160) {
+        return _getSqrtMarketTwapX96(baseToken, twapInterval);
+    }
+
+    /// @inheritdoc IExchange
+    function getSqrtMarketTwapX96(address baseToken, uint32 twapInterval) external view override returns (uint160) {
         return _getSqrtMarketTwapX96(baseToken, twapInterval);
     }
 

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -249,9 +249,9 @@ contract Exchange is
 
         // if updating TWAP fails, this call will be reverted and thus using try-catch
         try IBaseToken(baseToken).cacheTwap(IClearingHouseConfig(_clearingHouseConfig).getTwapInterval()) {} catch {}
-        uint256 markTwap;
+        uint256 marketTwap;
         uint256 indexTwap;
-        (fundingGrowthGlobal, markTwap, indexTwap) = _getFundingGrowthGlobalAndTwaps(baseToken);
+        (fundingGrowthGlobal, marketTwap, indexTwap) = _getFundingGrowthGlobalAndTwaps(baseToken);
 
         fundingPayment = _updateFundingGrowth(
             trader,
@@ -275,7 +275,7 @@ contract Exchange is
                 lastFundingGrowthGlobal.twPremiumDivBySqrtPriceX96
             ) = (timestamp, fundingGrowthGlobal.twPremiumX96, fundingGrowthGlobal.twPremiumDivBySqrtPriceX96);
 
-            emit FundingUpdated(baseToken, markTwap, indexTwap);
+            emit FundingUpdated(baseToken, marketTwap, indexTwap);
 
             // update tick for price limit checks
             _lastUpdatedTickMap[baseToken] = _getTick(baseToken);
@@ -354,13 +354,7 @@ contract Exchange is
     }
 
     /// @inheritdoc IExchange
-    // Deprecated function, will be removed in the next release
     function getSqrtMarkTwapX96(address baseToken, uint32 twapInterval) external view override returns (uint160) {
-        return _getSqrtMarketTwapX96(baseToken, twapInterval);
-    }
-
-    /// @inheritdoc IExchange
-    function getSqrtMarketTwapX96(address baseToken, uint32 twapInterval) external view override returns (uint160) {
         return _getSqrtMarketTwapX96(baseToken, twapInterval);
     }
 
@@ -601,14 +595,14 @@ contract Exchange is
 
     /// @dev this function calculates the up-to-date globalFundingGrowth and twaps and pass them out
     /// @return fundingGrowthGlobal the up-to-date globalFundingGrowth
-    /// @return markTwap only for settleFunding()
+    /// @return marketTwap only for settleFunding()
     /// @return indexTwap only for settleFunding()
     function _getFundingGrowthGlobalAndTwaps(address baseToken)
         internal
         view
         returns (
             Funding.Growth memory fundingGrowthGlobal,
-            uint256 markTwap,
+            uint256 marketTwap,
             uint256 indexTwap
         )
     {
@@ -625,9 +619,9 @@ contract Exchange is
             twapInterval = twapInterval > deltaTimestamp ? deltaTimestamp : twapInterval;
         }
 
-        uint256 markTwapX96;
+        uint256 marketTwapX96;
         if (marketOpen) {
-            markTwapX96 = _getSqrtMarketTwapX96(baseToken, twapInterval).formatSqrtPriceX96ToPriceX96();
+            marketTwapX96 = _getSqrtMarketTwapX96(baseToken, twapInterval).formatSqrtPriceX96ToPriceX96();
             indexTwap = IIndexPrice(baseToken).getIndexPrice(twapInterval);
         } else {
             // if a market is paused/closed, we use the last known index price which is getPausedIndexPrice
@@ -637,12 +631,12 @@ contract Exchange is
 
             // timestamp is pausedTime when the market is not open
             uint32 secondsAgo = _blockTimestamp().sub(timestamp).toUint32();
-            markTwapX96 = UniswapV3Broker
+            marketTwapX96 = UniswapV3Broker
                 .getSqrtMarketTwapX96From(IMarketRegistry(_marketRegistry).getPool(baseToken), secondsAgo, twapInterval)
                 .formatSqrtPriceX96ToPriceX96();
             indexTwap = IBaseToken(baseToken).getPausedIndexPrice();
         }
-        markTwap = markTwapX96.formatX96ToX10_18();
+        marketTwap = marketTwapX96.formatX96ToX10_18();
 
         uint256 lastSettledTimestamp = _lastSettledTimestampMap[baseToken];
         Funding.Growth storage lastFundingGrowthGlobal = _globalFundingGrowthX96Map[baseToken];
@@ -650,9 +644,9 @@ contract Exchange is
             // if this is the latest updated timestamp, values in _globalFundingGrowthX96Map are up-to-date already
             fundingGrowthGlobal = lastFundingGrowthGlobal;
         } else {
-            // deltaTwPremium = (markTwap - indexTwap) * (now - lastSettledTimestamp)
+            // deltaTwPremium = (marketTwap - indexTwap) * (now - lastSettledTimestamp)
             int256 deltaTwPremiumX96 =
-                _getDeltaTwapX96(markTwapX96, indexTwap.formatX10_18ToX96()).mul(
+                _getDeltaTwapX96(marketTwapX96, indexTwap.formatX10_18ToX96()).mul(
                     timestamp.sub(lastSettledTimestamp).toInt256()
                 );
             fundingGrowthGlobal.twPremiumX96 = lastFundingGrowthGlobal.twPremiumX96.add(deltaTwPremiumX96);
@@ -660,13 +654,13 @@ contract Exchange is
             // overflow inspection:
             // assuming premium = 1 billion (1e9), time diff = 1 year (3600 * 24 * 365)
             // log(1e9 * 2^96 * (3600 * 24 * 365) * 2^96) / log(2) = 246.8078491997 < 255
-            // twPremiumDivBySqrtPrice += deltaTwPremium / getSqrtMarkTwap(baseToken)
+            // twPremiumDivBySqrtPrice += deltaTwPremium / getSqrtMarketTwap(baseToken)
             fundingGrowthGlobal.twPremiumDivBySqrtPriceX96 = lastFundingGrowthGlobal.twPremiumDivBySqrtPriceX96.add(
                 PerpMath.mulDiv(deltaTwPremiumX96, PerpFixedPoint96._IQ96, _getSqrtMarketTwapX96(baseToken, 0))
             );
         }
 
-        return (fundingGrowthGlobal, markTwap, indexTwap);
+        return (fundingGrowthGlobal, marketTwap, indexTwap);
     }
 
     /// @dev get a price limit for replaySwap s.t. it can stop when reaching the limit to save gas
@@ -685,15 +679,15 @@ contract Exchange is
         return TickMath.getSqrtRatioAtTick(tickBoundary);
     }
 
-    function _getDeltaTwapX96(uint256 markTwapX96, uint256 indexTwapX96) internal view returns (int256 deltaTwapX96) {
+    function _getDeltaTwapX96(uint256 marketTwapX96, uint256 indexTwapX96) internal view returns (int256 deltaTwapX96) {
         uint24 maxFundingRate = IClearingHouseConfig(_clearingHouseConfig).getMaxFundingRate();
         uint256 maxDeltaTwapX96 = indexTwapX96.mulRatio(maxFundingRate);
         uint256 absDeltaTwapX96;
-        if (markTwapX96 > indexTwapX96) {
-            absDeltaTwapX96 = markTwapX96.sub(indexTwapX96);
+        if (marketTwapX96 > indexTwapX96) {
+            absDeltaTwapX96 = marketTwapX96.sub(indexTwapX96);
             deltaTwapX96 = absDeltaTwapX96 > maxDeltaTwapX96 ? maxDeltaTwapX96.toInt256() : absDeltaTwapX96.toInt256();
         } else {
-            absDeltaTwapX96 = indexTwapX96.sub(markTwapX96);
+            absDeltaTwapX96 = indexTwapX96.sub(marketTwapX96);
             deltaTwapX96 = absDeltaTwapX96 > maxDeltaTwapX96 ? maxDeltaTwapX96.neg256() : absDeltaTwapX96.neg256();
         }
     }

--- a/contracts/interface/IExchange.sol
+++ b/contracts/interface/IExchange.sol
@@ -103,12 +103,23 @@ interface IExchange {
         view
         returns (int256 pendingFundingPayment);
 
-    /// @notice Get the square root of the market twap price with the given time interval
+    /// @notice (Deprecated function, will be removed in the next release),
+    /// Get the square root of the market twap price with the given time interval
     /// @dev The return value is a X96 number
     /// @param baseToken Address of the base token
     /// @param twapInterval The time interval in seconds
     /// @return sqrtMarkTwapX96 The square root of the market twap price
     function getSqrtMarkTwapX96(address baseToken, uint32 twapInterval) external view returns (uint160 sqrtMarkTwapX96);
+
+    /// @notice Get the square root of the market twap price with the given time interval
+    /// @dev The return value is a X96 number
+    /// @param baseToken Address of the base token
+    /// @param twapInterval The time interval in seconds
+    /// @return sqrtMarketTwapX96 The square root of the market twap price
+    function getSqrtMarketTwapX96(address baseToken, uint32 twapInterval)
+        external
+        view
+        returns (uint160 sqrtMarketTwapX96);
 
     /// @notice Get the pnl that can be realized if trader reduce position
     /// @dev This function normally won't be needed by traders, but it might be useful for 3rd party

--- a/contracts/interface/IExchange.sol
+++ b/contracts/interface/IExchange.sol
@@ -103,23 +103,12 @@ interface IExchange {
         view
         returns (int256 pendingFundingPayment);
 
-    /// @notice (Deprecated function, will be removed in the next release),
-    /// Get the square root of the market twap price with the given time interval
+    /// @notice Get the square root of the market twap price with the given time interval
     /// @dev The return value is a X96 number
     /// @param baseToken Address of the base token
     /// @param twapInterval The time interval in seconds
     /// @return sqrtMarkTwapX96 The square root of the market twap price
     function getSqrtMarkTwapX96(address baseToken, uint32 twapInterval) external view returns (uint160 sqrtMarkTwapX96);
-
-    /// @notice Get the square root of the market twap price with the given time interval
-    /// @dev The return value is a X96 number
-    /// @param baseToken Address of the base token
-    /// @param twapInterval The time interval in seconds
-    /// @return sqrtMarketTwapX96 The square root of the market twap price
-    function getSqrtMarketTwapX96(address baseToken, uint32 twapInterval)
-        external
-        view
-        returns (uint160 sqrtMarketTwapX96);
 
     /// @notice Get the pnl that can be realized if trader reduce position
     /// @dev This function normally won't be needed by traders, but it might be useful for 3rd party

--- a/contracts/interface/IExchange.sol
+++ b/contracts/interface/IExchange.sol
@@ -47,9 +47,9 @@ interface IExchange {
 
     /// @notice Emitted when the global funding growth is updated
     /// @param baseToken Address of the base token
-    /// @param markTwap The market twap price when the funding growth is updated
+    /// @param marketTwap The market twap price when the funding growth is updated
     /// @param indexTwap The index twap price when the funding growth is updated
-    event FundingUpdated(address indexed baseToken, uint256 markTwap, uint256 indexTwap);
+    event FundingUpdated(address indexed baseToken, uint256 marketTwap, uint256 indexTwap);
 
     /// @notice Emitted when maxTickCrossedWithinBlock is updated
     /// @param baseToken Address of the base token
@@ -103,12 +103,23 @@ interface IExchange {
         view
         returns (int256 pendingFundingPayment);
 
-    /// @notice Get the square root of the market twap price with the given time interval
+    /// @notice (Deprecated function, will be removed in the next release)
+    /// Get the square root of the market twap price with the given time interval
     /// @dev The return value is a X96 number
     /// @param baseToken Address of the base token
     /// @param twapInterval The time interval in seconds
     /// @return sqrtMarkTwapX96 The square root of the market twap price
     function getSqrtMarkTwapX96(address baseToken, uint32 twapInterval) external view returns (uint160 sqrtMarkTwapX96);
+
+    /// @notice Get the square root of the market twap price with the given time interval
+    /// @dev The return value is a X96 number
+    /// @param baseToken Address of the base token
+    /// @param twapInterval The time interval in seconds
+    /// @return sqrtMarketTwapX96 The square root of the market twap price
+    function getSqrtMarketTwapX96(address baseToken, uint32 twapInterval)
+        external
+        view
+        returns (uint160 sqrtMarketTwapX96);
 
     /// @notice Get the pnl that can be realized if trader reduce position
     /// @dev This function normally won't be needed by traders, but it might be useful for 3rd party

--- a/contracts/lib/UniswapV3Broker.sol
+++ b/contracts/lib/UniswapV3Broker.sol
@@ -227,11 +227,11 @@ library UniswapV3Broker {
 
     /// @dev if twapInterval < 10 (should be less than 1 block), return mark price without twap directly,
     ///      as twapInterval is too short and makes getting twap over such a short period meaningless
-    function getSqrtMarkTwapX96(address pool, uint32 twapInterval) internal view returns (uint160) {
-        return getSqrtMarkTwapX96From(pool, 0, twapInterval);
+    function getSqrtMarketTwapX96(address pool, uint32 twapInterval) internal view returns (uint160) {
+        return getSqrtMarketTwapX96From(pool, 0, twapInterval);
     }
 
-    function getSqrtMarkTwapX96From(
+    function getSqrtMarketTwapX96From(
         address pool,
         uint32 secondsAgo,
         uint32 twapInterval

--- a/test/accountBalance/AccountBalance.getPositionValue.test.ts
+++ b/test/accountBalance/AccountBalance.getPositionValue.test.ts
@@ -108,7 +108,7 @@ describe("AccountBalance.getTotalPositionValue", () => {
             // which makes the mark price become 149.863446 (tick = 50099.75001)
 
             // if we get sqrtMarkTwapX96 with timeInterval == 0, the value should be same as the initial price = 151.3733069
-            // await clearingHouse.getSqrtMarkTwapX96(baseToken.address, 0)).toString() == 11993028956124528295336454433927
+            // await exchange.getSqrtMarketTwapX96(baseToken.address, 0)).toString() == 11993028956124528295336454433927
             // (11993028956124528295336454433927 / 2^96) = 151.3733068587
             // -> no need to pow(151.3733068587, 2) here as the initial value is already powered in their system, for unknown reason
 
@@ -198,7 +198,7 @@ describe("AccountBalance.getTotalPositionValue", () => {
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
                 return [0, parseUnits("150.092150", 6), 0, 0, 0]
             })
-            // expect(await clearingHouse.getSqrtMarkTwapX96(baseToken.address, 900)).eq("970640869716903962852171321230")
+            // expect(await exchange.getSqrtMarketTwapX96(baseToken.address, 900)).eq("970640869716903962852171321230")
 
             const markPrice = await accountBalance.getMarkPrice(baseToken.address)
             // current mark price: 150.092150435211957755
@@ -301,7 +301,7 @@ describe("AccountBalance.getTotalPositionValue", () => {
         mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
             return [0, parseUnits("152.711203", 6), 0, 0, 0]
         })
-        // expect(await clearingHouse.getSqrtMarkTwapX96(baseToken.address, 900)).eq("979072907636267862275708019389")
+        // expect(await exchange.getSqrtMarketTwapX96(baseToken.address, 900)).eq("979072907636267862275708019389")
 
         // current mark price:  148.361226800394579524
 
@@ -334,20 +334,3 @@ describe("AccountBalance.getTotalPositionValue", () => {
         )
     })
 })
-
-// // === useful console.log for verifying stats ===
-// console.log("getSqrtMarkTwapX96")
-// console.log((await clearingHouse.getSqrtMarkTwapX96(baseToken.address)).toString())
-
-// console.log("alice")
-// console.log("getTotalPositionSize")
-// console.log((await accountBalance.getTotalPositionSize(alice.address, baseToken.address)).toString())
-// console.log("getTotalPositionValue")
-// console.log((await accountBalance.getTotalPositionValue(alice.address, baseToken.address)).toString())
-
-// console.log("bob")
-// console.log("getTotalPositionSize")
-// console.log((await accountBalance.getTotalPositionSize(bob.address, baseToken.address)).toString())
-// console.log("getTotalPositionValue")
-// console.log((await accountBalance.getTotalPositionValue(bob.address, baseToken.address)).toString())
-// // === useful console.log for verifying stats ===

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -93,6 +93,6 @@ export async function syncMarkPriceToMarketPrice(
 }
 
 export async function getMarketTwap(exchange: Exchange, baseToken: BaseToken, interval: number) {
-    const sqrtPrice = await exchange.getSqrtMarkTwapX96(baseToken.address, interval)
+    const sqrtPrice = await exchange.getSqrtMarketTwapX96(baseToken.address, interval)
     return formatSqrtPriceX96ToPrice(sqrtPrice, 18)
 }

--- a/test/shared/utilities.ts
+++ b/test/shared/utilities.ts
@@ -93,6 +93,6 @@ export async function syncMarkPriceToMarketPrice(
 }
 
 export async function getMarketTwap(exchange: Exchange, baseToken: BaseToken, interval: number) {
-    const sqrtPrice = await exchange.getSqrtMarketTwapX96(baseToken.address, interval)
+    const sqrtPrice = await exchange.getSqrtMarkTwapX96(baseToken.address, interval)
     return formatSqrtPriceX96ToPrice(sqrtPrice, 18)
 }


### PR DESCRIPTION
Because the price spread and funding rate will keep referring to market twap after applying mark price.
To avoid variable name confusion, this PR is to rename markTwap to marketTwap.