### PR TITLE
Feature/price limit per n secs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Update the last tick of markets per 15 seconds.
 
 ## [2.4.2] - 2023-01-17
 - Ensure the trader's free collateral is enough for minimum maintenance requirement after closing a position.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-- Update the last tick of markets per 15 seconds.
+- Update the price limit check on last tick of markets per 15 (Exchange._PRICE_LIMIT_INTERVAL) seconds.
 
 ## [2.4.2] - 2023-01-17
 - Ensure the trader's free collateral is enough for minimum maintenance requirement after closing a position.

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -264,7 +264,7 @@ contract Exchange is
 
         // last tick will be stopped updating once the market is being paused
         uint256 lastTickUpdatedTimestamp = _lastTickUpdatedTimestampMap[baseToken];
-        if (lastTickUpdatedTimestamp == 0 || timestamp >= lastTickUpdatedTimestamp.add(_TICK_SNAPSHOT_INTERVAL)) {
+        if (timestamp >= lastTickUpdatedTimestamp.add(_TICK_SNAPSHOT_INTERVAL)) {
             // update tick for price limit checks
             _lastTickUpdatedTimestampMap[baseToken] = timestamp;
             _lastUpdatedTickMap[baseToken] = _getTick(baseToken);

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -85,7 +85,7 @@ contract Exchange is
     uint256 internal constant _FULLY_CLOSED_RATIO = 1e18;
     uint24 internal constant _MAX_TICK_CROSSED_WITHIN_BLOCK_CAP = 1000; // 10%
     uint24 internal constant _MAX_PRICE_SPREAD_RATIO = 0.1e6; // 10% in decimal 6
-    uint256 internal constant _TICK_SNAPSHOT_INTERVAL = 15; // 15 sec
+    uint256 internal constant _PRICE_LIMIT_INTERVAL = 15; // 15 sec
 
     //
     // EXTERNAL NON-VIEW
@@ -260,9 +260,9 @@ contract Exchange is
         }
 
         // update tick & timestamp for price limit check
-        // if timestamp diff < _TICK_SNAPSHOT_INTERVAL, including when the market is paused, they won't get updated
+        // if timestamp diff < _PRICE_LIMIT_INTERVAL, including when the market is paused, they won't get updated
         uint256 lastTickUpdatedTimestamp = _lastTickUpdatedTimestampMap[baseToken];
-        if (timestamp >= lastTickUpdatedTimestamp.add(_TICK_SNAPSHOT_INTERVAL)) {
+        if (timestamp >= lastTickUpdatedTimestamp.add(_PRICE_LIMIT_INTERVAL)) {
             _lastTickUpdatedTimestampMap[baseToken] = timestamp;
             _lastUpdatedTickMap[baseToken] = _getTick(baseToken);
         }

--- a/contracts/storage/ExchangeStorage.sol
+++ b/contracts/storage/ExchangeStorage.sol
@@ -13,6 +13,7 @@ abstract contract ExchangeStorageV1 {
 
     mapping(address => int24) internal _lastUpdatedTickMap;
     mapping(address => uint256) internal _firstTradedTimestampMap;
+    // the last timestamp when funding is settled
     mapping(address => uint256) internal _lastSettledTimestampMap;
     mapping(address => Funding.Growth) internal _globalFundingGrowthX96Map;
 
@@ -27,6 +28,7 @@ abstract contract ExchangeStorageV1 {
 }
 
 abstract contract ExchangeStorageV2 is ExchangeStorageV1 {
+    // the last timestamp when tick is updated; for price limit check
     // key: base token
     // value: the last timestamp to update the tick
     mapping(address => uint256) internal _lastTickUpdatedTimestampMap;

--- a/contracts/storage/ExchangeStorage.sol
+++ b/contracts/storage/ExchangeStorage.sol
@@ -20,6 +20,7 @@ abstract contract ExchangeStorageV1 {
     // value: a threshold to limit the price impact per block when reducing or closing the position
     mapping(address => uint24) internal _maxTickCrossedWithinBlockMap;
 
+    // _lastOverPriceLimitTimestampMap is deprecated
     // first key: trader, second key: baseToken
     // value: the last timestamp when a trader exceeds price limit when closing a position/being liquidated
     mapping(address => mapping(address => uint256)) internal _lastOverPriceLimitTimestampMap;

--- a/contracts/storage/ExchangeStorage.sol
+++ b/contracts/storage/ExchangeStorage.sol
@@ -24,3 +24,9 @@ abstract contract ExchangeStorageV1 {
     // value: the last timestamp when a trader exceeds price limit when closing a position/being liquidated
     mapping(address => mapping(address => uint256)) internal _lastOverPriceLimitTimestampMap;
 }
+
+abstract contract ExchangeStorageV2 is ExchangeStorageV1 {
+    // key: base token
+    // value: the last timestamp to update the tick
+    mapping(address => uint256) internal _lastTickUpdatedTimestampMap;
+}

--- a/test/clearingHouse/ClearingHouse.7494.badDebtAttack.test.ts
+++ b/test/clearingHouse/ClearingHouse.7494.badDebtAttack.test.ts
@@ -91,7 +91,7 @@ describe("ClearingHouse 7494 bad debt attack", () => {
             await q2bExactInput(fixture, account1, 6300)
 
             // forward timestamp to avoid _isOverPriceLimitWithTick
-            await forwardBothTimestamps(clearingHouse)
+            await forwardBothTimestamps(clearingHouse, 15)
             count++
         }
 

--- a/test/clearingHouse/ClearingHouse.openPosition.isReducePosition.ts
+++ b/test/clearingHouse/ClearingHouse.openPosition.isReducePosition.ts
@@ -4,7 +4,7 @@ import { expect } from "chai"
 import { parseUnits } from "ethers/lib/utils"
 import { waffle } from "hardhat"
 import { AccountBalance, BaseToken, Exchange, TestClearingHouse, TestERC20, Vault } from "../../typechain"
-import { addOrder, b2qExactInput, b2qExactOutput, q2bExactOutput } from "../helper/clearingHouseHelper"
+import { addOrder, b2qExactInput, q2bExactOutput } from "../helper/clearingHouseHelper"
 import { initMarket } from "../helper/marketHelper"
 import { deposit } from "../helper/token"
 import { ClearingHouseFixture, createClearingHouseFixture } from "./fixtures"
@@ -154,16 +154,19 @@ describe("ClearingHouse isIncreasePosition when trader is both of maker and take
         it("force error, reduce taker position and partial close when excess price limit", async () => {
             // alice add liquidity
             await addOrder(fixture, alice, 20, 1000, lowerTick, upperTick)
+            // max tick crossed: 1774544, current tick: 23027
 
             // bob swap let alice has maker position
             // alice maker positionSize : -10
             // alice taker positionSize: 0
             await q2bExactOutput(fixture, bob, 10)
+            //  max tick crossed: 1774544, current tick: 36890
 
             // alice swap
             // alice maker positionSize : -15
             // alice taker positionSize : 5
             await q2bExactOutput(fixture, alice, 5)
+            // max tick crossed: 1774544, current tick: 50754
 
             expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.deep.eq(
                 parseEther("5"),
@@ -171,9 +174,11 @@ describe("ClearingHouse isIncreasePosition when trader is both of maker and take
 
             // set MaxTickCrossedWithinBlock so that trigger over price limit
             await exchange.setMaxTickCrossedWithinBlock(baseToken.address, 1000)
+            // max tick crossed: 1000, current tick: 50754
+
             // expect revert due to over price limit
-            // alice reduce position
-            await expect(b2qExactOutput(fixture, alice, 5)).to.be.revertedWith("EX_OPLBS")
+            // alice reduce taker position
+            await expect(b2qExactInput(fixture, alice, 5)).to.be.revertedWith("EX_OPLAS")
         })
     })
 })

--- a/test/clearingHouse/ClearingHouse.partialClose.test.ts
+++ b/test/clearingHouse/ClearingHouse.partialClose.test.ts
@@ -109,10 +109,8 @@ describe("ClearingHouse partial close in xyk pool", () => {
 
             expect(await accountBalance.getTotalPositionSize(carol.address, baseToken.address)).eq(parseEther("-25"))
 
-            // move to next block to simplify test case
-            // otherwise we need to bring another trader to move the price further away
-
-            await forwardBothTimestamps(clearingHouse)
+            // move to next 15 secs to renew the over price checking window,to simplify test case
+            await forwardBothTimestamps(clearingHouse, 15)
 
             // price delta for every tick is 0.01%
             // if we want to limit price impact to 1%, and 1% / 0.01% = 100

--- a/test/foundry/clearingHouse/ClearingHouse.t.sol
+++ b/test/foundry/clearingHouse/ClearingHouse.t.sol
@@ -71,6 +71,9 @@ contract ClearingHouseTest is Setup {
         );
         vm.stopPrank();
 
+        // initiate timestamp to enable last tick update; should be larger than Exchange._TICK_SNAPSHOT_INTERVAL
+        vm.warp(block.timestamp + 100);
+
         // mock price oracle
     }
 

--- a/test/foundry/clearingHouse/ClearingHouse.t.sol
+++ b/test/foundry/clearingHouse/ClearingHouse.t.sol
@@ -71,7 +71,7 @@ contract ClearingHouseTest is Setup {
         );
         vm.stopPrank();
 
-        // initiate timestamp to enable last tick update; should be larger than Exchange._TICK_SNAPSHOT_INTERVAL
+        // initiate timestamp to enable last tick update; should be larger than Exchange._PRICE_LIMIT_INTERVAL
         vm.warp(block.timestamp + 100);
 
         // mock price oracle

--- a/test/foundry/immunefi/14204.BadDebtAttack.t.sol
+++ b/test/foundry/immunefi/14204.BadDebtAttack.t.sol
@@ -366,6 +366,9 @@ contract BadDebtAttackTest is Setup {
             })
         );
         vm.stopPrank();
+
+        // initiate timestamp to enable last tick update; should be larger than Exchange._TICK_SNAPSHOT_INTERVAL
+        vm.warp(block.timestamp + 100);
     }
 
     function testAttack_beforeHotfix_shouldPass() public {

--- a/test/foundry/immunefi/14204.BadDebtAttack.t.sol
+++ b/test/foundry/immunefi/14204.BadDebtAttack.t.sol
@@ -367,7 +367,7 @@ contract BadDebtAttackTest is Setup {
         );
         vm.stopPrank();
 
-        // initiate timestamp to enable last tick update; should be larger than Exchange._TICK_SNAPSHOT_INTERVAL
+        // initiate timestamp to enable last tick update; should be larger than Exchange._PRICE_LIMIT_INTERVAL
         vm.warp(block.timestamp + 100);
     }
 


### PR DESCRIPTION
**Background**

> In bedrock blocks are produced every two seconds, regardless of whether there are transactions to put in them or not.

Currently, to prevent price manipulation in short time, the protocol limits the price moves by block timestamp (block period is around 12~15 secs).
But, after bedrock release, the price manipulation would be easier since the block period is reduced to 2 secs. 


**Solution**

The protocol will snapshot current market tick by 15 secs instead of by block timestamp. In other words, the market price can not move over price limit within 15 secs.
