### PR TITLE
Feature: Add getters in exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Add `Exchange.getFirstTradedTimestamp()`
+- Add `Exchange.getLastSettledTimestamp()`
+- Add `Exchange.getLastFundingGrowthGlobal()`
 
 ## [2.4.3] - 2023-02-07
 - Update the price limit check on last tick of markets per 15 (Exchange._PRICE_LIMIT_INTERVAL) seconds.

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -295,6 +295,21 @@ contract Exchange is
     }
 
     /// @inheritdoc IExchange
+    function getFirstTradedTimestamp(address baseToken) external view override returns (uint256) {
+        return _firstTradedTimestampMap[baseToken];
+    }
+
+    /// @inheritdoc IExchange
+    function getLastSettledTimestamp(address baseToken) external view override returns (uint256) {
+        return _lastSettledTimestampMap[baseToken];
+    }
+
+    /// @inheritdoc IExchange
+    function getLastFundingGrowthGlobal(address baseToken) external view override returns (Funding.Growth memory) {
+        return _globalFundingGrowthX96Map[baseToken];
+    }
+
+    /// @inheritdoc IExchange
     function getPnlToBeRealized(RealizePnlParams memory params) external view override returns (int256) {
         AccountMarket.Info memory info =
             IAccountBalance(_accountBalance).getAccountInfo(params.trader, params.baseToken);

--- a/contracts/interface/IExchange.sol
+++ b/contracts/interface/IExchange.sol
@@ -83,6 +83,24 @@ interface IExchange {
     /// @return maxTickCrossedWithinBlock The max ticks allowed to be crossed within a block when reducing position
     function getMaxTickCrossedWithinBlock(address baseToken) external view returns (uint24 maxTickCrossedWithinBlock);
 
+    /// @notice Get the timestamp of the first tx in this market
+    /// @param baseToken Address of the base token
+    /// @return firstTradedTimestamp The timestamp of the first tx in this market
+    function getFirstTradedTimestamp(address baseToken) external view returns (uint256 firstTradedTimestamp);
+
+    /// @notice Get the last timestamp when funding is settled
+    /// @param baseToken Address of the base token
+    /// @return lastSettledTimestamp The last timestamp when funding is settled
+    function getLastSettledTimestamp(address baseToken) external view returns (uint256 lastSettledTimestamp);
+
+    /// @notice Get the global funding growth when the last funding is settled
+    /// @param baseToken Address of the base token
+    /// @return lastFundingGrowthGlobal The global funding growth when the last funding is settled
+    function getLastFundingGrowthGlobal(address baseToken)
+        external
+        view
+        returns (Funding.Growth memory lastFundingGrowthGlobal);
+
     /// @notice Get all the pending funding payment for a trader
     /// @return pendingFundingPayment The pending funding payment of the trader.
     /// Positive value means the trader pays funding, negative value means the trader receives funding.


### PR DESCRIPTION
### Background

Sometimes you need to use `FirstTradedTimestamp`, `LastSettledTimestamp`, and `LastFundingGrowthGlobal` for statistics. Although I can find them through contract events, I think it would be very convenient if you can use some getters, so I added the following functions:

* Exchange.getFirstTradedTimestamp
* Exchange.getLastSettledTimestamp
* Exchange.getLastFundingGrowthGlobal

### PR Reminders

Be ware of the followings

- [ ] implement deployment script for your changes in deployment repo
- [ ] add verification in hardhat simulation(000-prepare-simulation-check, 902-newMarket-check or 903-simulation-check) and system test(901-system-test) in deployment repo
- [x] update change log
 
---

1. **Contract**: make sure the code follows our convention, ex: naming, explicit returns, etc.; if uncertain, discuss with others

2. **Test**: make sure tests can cover most normal and edge cases; if not, open follow-up tickets. Also, look out for failed tests and fix them!

3. **CHANGELOG.md**: update when external interfaces are changed

4. Workflow: 
    - Github: assign the pr to yourself; if pairing, can merge directly; else, assign someone to help review
    - Asana: assign the corresponding ticket to yourself and leave the pr link on it for easier follow-ups
    - Discord: if someone is mentioned in this pr, tag on Discord