### PR TITLE
fix tests for price band

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -737,13 +737,11 @@ contract Exchange is
 
     /// @dev ratio will return in int256
     function _getPriceSpreadRatio(address baseToken) internal view returns (int256) {
-        int256 marketPrice =
-            getSqrtMarkTwapX96(baseToken, 0).formatSqrtPriceX96ToPriceX96().formatX96ToX10_18().toInt256();
-        int256 indexTwap =
-            IIndexPrice(baseToken)
-                .getIndexPrice(IClearingHouseConfig(_clearingHouseConfig).getTwapInterval())
-                .toInt256();
-        int256 spread = marketPrice.sub(indexTwap);
-        return spread.mulDiv(1e6, indexTwap.toUint256());
+        uint256 marketPrice = getSqrtMarkTwapX96(baseToken, 0).formatSqrtPriceX96ToPriceX96().formatX96ToX10_18();
+        uint256 indexTwap =
+            IIndexPrice(baseToken).getIndexPrice(IClearingHouseConfig(_clearingHouseConfig).getTwapInterval());
+        int256 spread =
+            marketPrice > indexTwap ? marketPrice.sub(indexTwap).toInt256() : indexTwap.sub(marketPrice).neg256();
+        return spread.mulDiv(1e6, indexTwap);
     }
 }

--- a/test/clearingHouse/ClearingHouse.stopMarket.test.ts
+++ b/test/clearingHouse/ClearingHouse.stopMarket.test.ts
@@ -154,6 +154,11 @@ describe("Clearinghouse StopMarket", async () => {
 
         describe("funding payment", async () => {
             beforeEach(async () => {
+                // mock index price to do long
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("150", 6), 0, 0, 0]
+                })
+
                 // bob open long position
                 for (let i = 0; i < 3; i++) {
                     await q2bExactInput(fixture, bob, 10 + i * 5, baseToken.address)
@@ -244,12 +249,20 @@ describe("Clearinghouse StopMarket", async () => {
         })
 
         describe("accounting", async () => {
+            let pausedIndexPrice = "50"
             beforeEach(async () => {
+                // mock index price to do long
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("150", 6), 0, 0, 0]
+                })
+
                 // open position on two market
                 await q2bExactInput(fixture, bob, 10, baseToken.address)
+                // market price: 152.57455726629748304
 
+                // mock index price as pause price
                 mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
-                    return [0, parseUnits("50", 6), 0, 0, 0]
+                    return [0, parseUnits(pausedIndexPrice, 6), 0, 0, 0]
                 })
 
                 await pauseMarket(baseToken)
@@ -268,7 +281,7 @@ describe("Clearinghouse StopMarket", async () => {
 
                 // TODO: why don't we use getTotalPositionValue here?
                 expect(bobUnrealizedPnl).to.be.eq(
-                    bobStoppedMarketPositionSize.mul("50").add(bobStoppedMarketQuoteBalance),
+                    bobStoppedMarketPositionSize.mul(pausedIndexPrice).add(bobStoppedMarketQuoteBalance),
                 )
 
                 const aliceStoppedMarketPositionSize = await accountBalance.getTotalPositionSize(
@@ -282,7 +295,7 @@ describe("Clearinghouse StopMarket", async () => {
                 const [, aliceUnrealizedPnl] = await accountBalance.getPnlAndPendingFee(alice.address)
 
                 expect(aliceUnrealizedPnl).to.be.closeTo(
-                    aliceStoppedMarketPositionSize.mul("50").add(aliceStoppedMarketQuoteBalance),
+                    aliceStoppedMarketPositionSize.mul(pausedIndexPrice).add(aliceStoppedMarketQuoteBalance),
                     1,
                 )
             })
@@ -306,8 +319,8 @@ describe("Clearinghouse StopMarket", async () => {
                     baseToken.address,
                 )
 
-                expect(bobStoppedMarketPositionValue).to.be.eq(bobStoppedMarketPositionSize.mul("50"))
-                expect(aliceStoppedMarketPositionValue).to.be.eq(aliceStoppedMarketPositionSize.mul("50"))
+                expect(bobStoppedMarketPositionValue).to.be.eq(bobStoppedMarketPositionSize.mul(pausedIndexPrice))
+                expect(aliceStoppedMarketPositionValue).to.be.eq(aliceStoppedMarketPositionSize.mul(pausedIndexPrice))
             })
         })
     })
@@ -901,6 +914,11 @@ describe("Clearinghouse StopMarket", async () => {
             // Bob as taker in baseToken market
             await addOrder(fixture, alice, 300, 30000, lowerTick, upperTick, false, baseToken.address)
 
+            // mock index price to do long
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("250", 6), 0, 0, 0]
+            })
+
             // Bob swaps on baseToken market, use for loop due to MaxTickCrossedWithinBlock limit
             for (let i = 0; i < 10; i++) {
                 await q2bExactInput(fixture, bob, 1000, baseToken.address)
@@ -931,18 +949,26 @@ describe("Clearinghouse StopMarket", async () => {
             // Bob add liquidity to baseToken2 market
             await addOrder(fixture, bob, 50, 5000, lowerTick, upperTick, false, baseToken2.address)
 
+            // mock index price to do long
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("250", 6), 0, 0, 0]
+            })
+
             // Bob swaps on baseToken market, use for loop due to MaxTickCrossedWithinBlock limit
             for (let i = 0; i < 10; i++) {
                 await q2bExactInput(fixture, bob, 1000, baseToken.address)
                 await forwardBothTimestamps(clearingHouse, 100)
             }
 
-            await pauseMarket(baseToken2)
-
             // drop price on baseToken market
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
-                return [0, parseUnits("0.000001", 6), 0, 0, 0]
+                return [0, parseUnits("50", 6), 0, 0, 0]
             })
+
+            // make bob to pay funding payment to make him to be liquidated
+            await forwardBothTimestamps(clearingHouse, 86400)
+
+            await pauseMarket(baseToken2)
 
             // Bob's free collateral should be 0 if his position is underwater
             expect(await vault.getFreeCollateral(bob.address)).to.be.eq("0")
@@ -962,6 +988,11 @@ describe("Clearinghouse StopMarket", async () => {
             // bob add liquidity to baseToken2 market
             await addOrder(fixture, bob, 50, 5000, lowerTick, upperTick, false, baseToken2.address)
 
+            // mock index price to do long
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("250", 6), 0, 0, 0]
+            })
+
             // Bob swaps on baseToken market, use for loop due to MaxTickCrossedWithinBlock limit
             for (let i = 0; i < 10; i++) {
                 await q2bExactInput(fixture, bob, 1000, baseToken.address)
@@ -973,8 +1004,11 @@ describe("Clearinghouse StopMarket", async () => {
 
             // drop price on baseToken market
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
-                return [0, parseUnits("0.000001", 6), 0, 0, 0]
+                return [0, parseUnits("50", 6), 0, 0, 0]
             })
+
+            // make bob to pay funding payment to make him to be liquidated
+            await forwardBothTimestamps(clearingHouse, 86400)
 
             // Bob's free collateral should be 0 if his position is underwater
             expect(await vault.getFreeCollateral(bob.address)).to.be.eq("0")

--- a/test/clearingHouse/ClearingHouse.swap.test.ts
+++ b/test/clearingHouse/ClearingHouse.swap.test.ts
@@ -98,6 +98,11 @@ describe("ClearingHouse.swap", () => {
 
         describe("reduce 25% position (exactInput), profit", () => {
             beforeEach(async () => {
+                // mock index price to do short
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("8", 6), 0, 0, 0]
+                })
+
                 // another trader carol sell base, price down
                 await collateral.mint(carol.address, parseUnits("100", collateralDecimals))
                 await deposit(carol, vault, 100, collateral)
@@ -108,6 +113,7 @@ describe("ClearingHouse.swap", () => {
                     amount: parseEther("10"),
                     sqrtPriceLimitX96: 0,
                 })
+                // market price: 8.116224332440548657
 
                 // bob reduce 25% position
                 await clearingHouse.connect(bob).swap({
@@ -117,6 +123,7 @@ describe("ClearingHouse.swap", () => {
                     amount: parseEther("0.25"),
                     sqrtPriceLimitX96: 0,
                 })
+                //market price: 8.152907785517378433
             })
 
             it("openNotionalAbs--", async () => {
@@ -174,6 +181,11 @@ describe("ClearingHouse.swap", () => {
         beforeEach(async () => {
             await collateral.mint(bob.address, parseUnits("25", collateralDecimals))
             await deposit(bob, vault, 25, collateral)
+
+            // mock index price to do long
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("20", 6), 0, 0, 0]
+            })
             await clearingHouse.connect(bob).swap({
                 // buy base
                 baseToken: baseToken.address,
@@ -182,6 +194,8 @@ describe("ClearingHouse.swap", () => {
                 amount: parseEther("250"),
                 sqrtPriceLimitX96: 0,
             })
+            // market price: 15.5625625
+
             initOpenNotional = await accountBalance.getTotalOpenNotional(bob.address, baseToken.address)
             posSizeBefore = await accountBalance.getTotalPositionSize(bob.address, baseToken.address)
         })
@@ -207,6 +221,11 @@ describe("ClearingHouse.swap", () => {
 
         describe("reduce 75% position (exactOutput), loss", () => {
             beforeEach(async () => {
+                // mock index price to do short
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("10", 6), 0, 0, 0]
+                })
+
                 // another trader carol sell base, price down
                 await collateral.mint(carol.address, parseUnits("10000", collateralDecimals))
                 await deposit(carol, vault, 10000, collateral)
@@ -246,6 +265,11 @@ describe("ClearingHouse.swap", () => {
 
         describe("swap reverse and larger amount, only fee loss", () => {
             beforeEach(async () => {
+                // mock index price to do short
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("5", 6), 0, 0, 0]
+                })
+
                 // bob opens a larger reverse position (short)
                 await collateral.mint(bob.address, parseUnits("1000", collateralDecimals))
                 await deposit(bob, vault, 1000, collateral)
@@ -256,6 +280,7 @@ describe("ClearingHouse.swap", () => {
                     amount: parseEther("400"),
                     sqrtPriceLimitX96: 0,
                 })
+                // market price: 7.114240900163248648
             })
 
             it("realizedPnl is negative", async () => {

--- a/test/clearingHouse/ClearingHouse.takeOver.test.ts
+++ b/test/clearingHouse/ClearingHouse.takeOver.test.ts
@@ -462,10 +462,17 @@ describe("ClearingHouse takeOver (liquidate)", () => {
             })
 
             it("davis has long position and liquidates bob's long position, no pnl realized", async () => {
+                // mock index price to do long
+                setPool1IndexPrice(1000)
+
                 // davis long ETH before liquidate bob's ETH long position
                 // quote: -1010.149094153067713775
                 // base: 1
                 await q2bExactOutput(fixture, davis, 1, baseToken.address)
+                // market price: 1000.06357828794760671
+
+                // mock index price to make bob's margin ratio is within 3.125% and 6.25%
+                setPool1IndexPrice(900)
 
                 // liquidate when
                 // marginRatio 0.045
@@ -636,10 +643,16 @@ describe("ClearingHouse takeOver (liquidate)", () => {
             })
 
             it("davis has long position and liquidates bob's long position, no pnl realized", async () => {
+                // mock index price to do long
+                setPool1IndexPrice(1000)
+
                 // davis long ETH before liquidate bob's ETH long position
                 // quote: -1010.149094153067713775
                 // base: 1
                 await q2bExactOutput(fixture, davis, 1, baseToken.address)
+
+                // mock index price to make bob's margin ratio is below 3.125%
+                setPool1IndexPrice(880)
 
                 // liquidate when
                 // marginRatio 0.024

--- a/test/clearingHouse/ClearingHouse.verifyAccounting.test.ts
+++ b/test/clearingHouse/ClearingHouse.verifyAccounting.test.ts
@@ -144,11 +144,11 @@ describe("ClearingHouse verify accounting", () => {
             })
 
             it("q2bExactInput", async () => {
-                await q2bExactInput(fixture, alice, 100)
+                await q2bExactInput(fixture, alice, 10)
             })
 
             it("b2qExactOutput", async () => {
-                await b2qExactOutput(fixture, alice, 100)
+                await b2qExactOutput(fixture, alice, 10)
             })
 
             it("b2qExactInput", async () => {
@@ -161,7 +161,7 @@ describe("ClearingHouse verify accounting", () => {
             await q2bExactOutput(fixture, alice, 1)
 
             // bob
-            await b2qExactOutput(fixture, bob, 100)
+            await b2qExactOutput(fixture, bob, 10)
 
             // carol
             await b2qExactInput(fixture, carol, 1)
@@ -169,14 +169,14 @@ describe("ClearingHouse verify accounting", () => {
 
         it("takerAddLiquidityWhileHavingPosition", async () => {
             // alice take position
-            await q2bExactInput(fixture, alice, 100)
+            await q2bExactInput(fixture, alice, 10)
 
             // bob take position, bob profit++
-            await q2bExactInput(fixture, bob, 100)
+            await q2bExactInput(fixture, bob, 10)
 
             // alice
             await syncIndexToMarketPrice(mockedBaseAggregator, pool)
-            await addOrder(fixture, alice, 1, 100, lowerTick, upperTick)
+            await addOrder(fixture, alice, 1, 10, lowerTick, upperTick)
             await removeOrder(fixture, alice, 0, lowerTick, upperTick)
             await closePosition(fixture, alice)
 
@@ -186,11 +186,11 @@ describe("ClearingHouse verify accounting", () => {
 
         it("makerOpenPosition", async () => {
             // alice
-            await addOrder(fixture, alice, 1, 100, lowerTick, upperTick)
-            await q2bExactInput(fixture, alice, 100)
+            await addOrder(fixture, alice, 1, 10, lowerTick, upperTick)
+            await q2bExactInput(fixture, alice, 10)
 
             // bob take position, bob profit++
-            await q2bExactInput(fixture, bob, 100)
+            await q2bExactInput(fixture, bob, 10)
         })
     }
 })

--- a/test/foundry/immunefi/14204.BadDebtAttack.t.sol
+++ b/test/foundry/immunefi/14204.BadDebtAttack.t.sol
@@ -410,11 +410,11 @@ contract BadDebtAttackTest is Setup {
         badDebter.unlimitedLP(address(baseToken), 200000 ether);
 
         console.log("7. badDebter close position and realize a huge loss");
-        vm.expectRevert(bytes("EX_OPSAS"));
+        vm.expectRevert(bytes("EX_OPB"));
         badDebter.closePosition(address(baseToken), Utils.getSqrtRatioAtTick(Utils.MIN_TICK) + 100);
 
         console.log("8. exploiter close position and take the profit");
-        vm.expectRevert(bytes("EX_OPSAS"));
+        vm.expectRevert(bytes("EX_OPB"));
         exploiter.closePosition(address(baseToken), Utils.getSqrtRatioAtTick(Utils.MAX_TICK) - 100);
 
         exploiter.withdrawAll();
@@ -446,7 +446,7 @@ contract BadDebtAttackTest is Setup {
                 // half of usdcAmount goes to exploiter, another half goes to badDebter
                 usdc.transfer(address(exploiter), usdcAmount);
 
-                vm.expectRevert(bytes("EX_OPSAS"));
+                vm.expectRevert(bytes("EX_OPB"));
                 exploiter.attack2(address(baseToken), tick + 60 * i, usdcAmount / 2);
 
                 // the revert will be caught by Foundry,

--- a/test/vault/Vault.liquidate.test.ts
+++ b/test/vault/Vault.liquidate.test.ts
@@ -181,7 +181,13 @@ describe("Vault liquidate test (assume zero IF fee)", () => {
 
             it("usdc debt is greater than the debt threshold", async () => {
                 await deposit(alice, vault, 20, weth)
+                // mock index price to do long
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("300", 6), 0, 0, 0]
+                })
                 await q2bExactInput(fixture, alice, 27000)
+                // mark price: 292.357324025874445567
+
                 mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
                     return [0, parseUnits("75", 6), 0, 0, 0]
                 })
@@ -234,15 +240,45 @@ describe("Vault liquidate test (assume zero IF fee)", () => {
 
             it("trader is liquidatable when usdc debt greater than debt threshold", async () => {
                 await deposit(alice, vault, 10, weth)
+
+                // mock index price to do long
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("200", 6), 0, 0, 0]
+                })
                 await q2bExactInput(fixture, alice, 10000)
+                // market price: 193.258483282323921107
+
+                // mock index price to do short
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("100", 6), 0, 0, 0]
+                })
                 await b2qExactOutput(fixture, bob, 20000)
+                // market price: 113.212192136080329948
+
+                // mock index price to do short for closing position
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("90", 6), 0, 0, 0]
+                })
                 // alice's total realized pnl: -4099.33124393
                 await closePosition(fixture, alice)
+                // market Price: 93.660475463498713498
 
                 expect(await vault.isLiquidatable(alice.address)).to.be.false
 
+                // mock index price to do long
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("200", 6), 0, 0, 0]
+                })
                 await q2bExactInput(fixture, alice, 15000)
+                // market price: 145.814586890320505535
+
+                // mock index price to do short
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("50", 6), 0, 0, 0]
+                })
                 await b2qExactOutput(fixture, bob, 25000)
+                // market price: 63.97349846992365722
+
                 // alice's total realized pnl: -12185.86442144
                 await closePosition(fixture, alice)
 
@@ -291,7 +327,13 @@ describe("Vault liquidate test (assume zero IF fee)", () => {
             await deposit(alice, vault, 1, weth)
             await deposit(alice, vault, 0.02355323, wbtc)
             await deposit(alice, vault, 1.1237, xxx)
+
+            // mock index price to do long
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("170", 6), 0, 0, 0]
+            })
             await q2bExactInput(fixture, alice, 5000)
+            // market price: 171.677208074842359898
         })
 
         it("force error, not liquidatable", async () => {
@@ -880,12 +922,22 @@ describe("Vault liquidate test (assume zero IF fee)", () => {
                 // set a large debt dust for convenience
                 await collateralManager.setCollateralValueDust(parseUnits("100000", usdcDecimals))
 
+                // mock index price to do long
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("200", 6), 0, 0, 0]
+                })
                 // alice continue to open long position
-                await syncIndexToMarketPrice(mockedBaseAggregator, pool)
                 await q2bExactInput(fixture, alice, 10000)
+                // market price: 216.117132481167910279
 
+                // mock index price to do short
+                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                    return [0, parseUnits("140", 6), 0, 0, 0]
+                })
                 // bob short to make alice has bad debt
-                await b2qExactOutput(fixture, bob, 80000)
+                await b2qExactOutput(fixture, bob, 20000)
+                // market price: 130.857601904815440587
+
                 await syncIndexToMarketPrice(mockedBaseAggregator, pool)
             })
 
@@ -959,7 +1011,7 @@ describe("Vault liquidate test (assume zero IF fee)", () => {
                 const IFSettlementTokenValueBefore = await vault.getSettlementTokenValue(insuranceFund.address)
 
                 // in last liquidation, settle bad debt
-                const badDebt = parseUnits("11269.339945", usdcDecimals)
+                const badDebt = parseUnits("1013.286615", usdcDecimals)
                 const IFFee = parseUnits("24.536583", usdcDecimals) // 817.886106 * 0.03 = 24.536583
                 await expect(
                     vault

--- a/test/vault/Vault.liquidationGetter.test.ts
+++ b/test/vault/Vault.liquidationGetter.test.ts
@@ -74,9 +74,16 @@ describe("Vault liquidationGetter test", () => {
         // debt = 9000 (> collateralValueDust = 500), eth = 1, liquidation ratio = 0.5,
         // discount rate = 0.1, cl insurance rate = 0.03
         it("discounted collateral value less than max repay notional", async () => {
-            await q2bExactInput(fixture, alice, 10000)
+            // mock index price to do long
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
-                return [0, parseUnits("0", 6), 0, 0, 0]
+                return [0, parseUnits("200", 6), 0, 0, 0]
+            })
+
+            await q2bExactInput(fixture, alice, 10000)
+
+            // mock index price to make bad debt
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("50", 6), 0, 0, 0]
             })
             // maxRepaidSettlementX10_S = 1 * 2700 = 2700
             // maxLiquidatableCollateral = min(4500 (= 9000 * 0.5, cuz collateralValueDust = 500) / 0.97 / (3000 * 0.9), 1) = 1
@@ -154,6 +161,12 @@ describe("Vault liquidationGetter test", () => {
         beforeEach(async () => {
             await deposit(alice, vault, 1000, usdc)
             await deposit(alice, vault, 1, weth)
+
+            // mock index price to do long
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("200", 6), 0, 0, 0]
+            })
+
             // totalMarginRequirement = 4000 * 10% = 400
             await q2bExactInput(fixture, alice, 4000)
             // position size = 24.868218

--- a/test/vault/Vault.test.ts
+++ b/test/vault/Vault.test.ts
@@ -355,14 +355,15 @@ describe("Vault test", () => {
 
                 // total position size: 18.52739798
                 // total quote balance in order: 60.47455739
-                // unrealized PnL: 18.52739798 * 180 - 3000 + 60.47455739 = 395.406193
-                // pending maker fee: 0.61085412
-                // pending funding payment: -0.37171688
-                // settlement token value: 1000 + 0.61085412 - (-0.37171688) + 395.406193 = 1396.388764
+                // total open notional: -3000 + 60.47455739 = -2939.52544261
+                // unrealized PnL: 18.52739798 * 180 - 2939.52544261 = 395.40619379
+                // pending maker fee: 0.549769
+                // pending funding payment: -0.371717
+                // settlement token value: 1000 + 0.549769 - (-0.371717) + 395.40619379 = 1396.327679
                 expect(await vault.getSettlementTokenValue(alice.address)).to.be.closeTo(
-                    parseUnits("1396.388764", usdcDecimals),
-                    // there can be a huge imprecision, thus giving an about 0.05% fault tolerance range
-                    parseUnits("0.5", usdcDecimals).toNumber(),
+                    parseUnits("1396.327679", usdcDecimals),
+                    // there can be a little imprecision due to pending funding payment and decimal conversion
+                    parseUnits("0.01", usdcDecimals).toNumber(),
                 )
             })
 
@@ -454,7 +455,8 @@ describe("Vault test", () => {
                 // settlement token value: 0.054976870352004751 - (-1.219374926076949977) + 398.5977612193 = 399.872113
                 expect(await vault.getSettlementTokenValue(alice.address)).to.be.closeTo(
                     parseUnits("399.872113", usdcDecimals),
-                    parseUnits("0.1", usdcDecimals).toNumber(),
+                    // there can be a little imprecision due to pending funding payment and decimal conversion
+                    parseUnits("0.01", usdcDecimals).toNumber(),
                 )
             })
         })
@@ -474,13 +476,14 @@ describe("Vault test", () => {
                 return [0, parseUnits("100", 6), 0, 0, 0]
             })
             await forwardBothTimestamps(clearingHouse, 360)
-            // unrealized PnL: 100 * 18.88437579 - 3000 = -1111.562421
-            // funding payment: 0.80214883
-            // account value: 500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7 - 0.80214883 - 1111.562421 = -122.364569
+
+            // unrealized PnL: 100 * 18.884375790674023929 - 3000 = -1111.5624209326
+            // funding payment: 0.78684899127808433
+            // account value: 500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7 - 0.78684899127808433 - 1111.5624209326 = -122.349267
             expect(await vault.getAccountValue(alice.address)).to.be.closeTo(
-                parseUnits("-122.364568", usdcDecimals),
-                // there can be a huge imprecision, thus giving an about 0.05% fault tolerance range
-                parseUnits("0.05", usdcDecimals).toNumber(),
+                parseUnits("-122.349267", usdcDecimals),
+                // there can be a little imprecision due to pending funding payment and decimal conversion
+                parseUnits("0.01", usdcDecimals).toNumber(),
             )
         })
 
@@ -490,12 +493,12 @@ describe("Vault test", () => {
             })
             await forwardBothTimestamps(clearingHouse, 360)
             // unrealized PnL: 180 * 18.88437579 - 3000 = 399.1876422
-            // funding payment: -1.35194469
-            // account value: 500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7 - (-1.35194469) + 399.1876422 = 1390.53958689
+            // funding payment: -1.326158286620314967
+            // account value: 500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7 - (-1.326158286620314967) + 399.1876422 = 1390.513800
             expect(await vault.getAccountValue(alice.address)).to.be.closeTo(
-                parseUnits("1390.539586", usdcDecimals),
-                // there can be a huge imprecision, thus giving an about 0.05% fault tolerance range
-                parseUnits("0.5", usdcDecimals).toNumber(),
+                parseUnits("1390.513800", usdcDecimals),
+                // there can be a little imprecision due to pending funding payment and decimal conversion
+                parseUnits("0.01", usdcDecimals).toNumber(),
             )
         })
 
@@ -513,14 +516,14 @@ describe("Vault test", () => {
 
             // total position size: 18.84750169711406076
             // total open notional: -2993.952544261279477388
-            // unrealized PnL: 18.84750169711406076 * 180 -2993.952544261279477388 = 398.5977612193
+            // unrealized PnL: 18.84750169711406076 * 180 - 2993.952544261279477388 = 398.5977612193
             // pending maker fee: 0.054976870352004751
             // pending funding payment: -1.230993742106468956
             // account value: (500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7) + 0.054976870352004751 - (-1.219374926076949977) + 398.5977612193 = 1389.872113
             expect(await vault.getAccountValue(alice.address)).to.be.closeTo(
                 parseUnits("1389.872113", usdcDecimals),
-                // there can be a huge imprecision, thus giving an about 0.05% fault tolerance range
-                parseUnits("0.5", usdcDecimals).toNumber(),
+                // there can be a little imprecision due to pending funding payment and decimal conversion
+                parseUnits("0.1", usdcDecimals).toNumber(),
             )
         })
 
@@ -539,11 +542,7 @@ describe("Vault test", () => {
 
             // realized PnL(including funding): 13.096488
             // account value: 500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7 + 13.096488 = 1003.096488
-            expect(await vault.getAccountValue(alice.address)).to.be.closeTo(
-                parseUnits("1003.096488", usdcDecimals),
-                // there can be a huge imprecision, thus giving an about 0.05% fault tolerance range
-                parseUnits("0.5", usdcDecimals).toNumber(),
-            )
+            expect(await vault.getAccountValue(alice.address)).eq(parseUnits("1003.096488", usdcDecimals))
         })
 
         it("trader has negative realized PnL", async () => {
@@ -561,11 +560,7 @@ describe("Vault test", () => {
 
             // realized PnL(including funding): -132.803228
             // account value: 500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7 - 132.803228 = 857.196772
-            expect(await vault.getAccountValue(alice.address)).to.be.closeTo(
-                parseUnits("857.196772", usdcDecimals),
-                // there can be a huge imprecision, thus giving an about 0.05% fault tolerance range
-                parseUnits("0.5", usdcDecimals).toNumber(),
-            )
+            expect(await vault.getAccountValue(alice.address)).eq(parseUnits("857.196772", usdcDecimals))
         })
     })
 })

--- a/test/vault/Vault.test.ts
+++ b/test/vault/Vault.test.ts
@@ -340,6 +340,8 @@ describe("Vault test", () => {
             })
 
             it("trader is both maker & taker", async () => {
+                await syncIndexToMarketPrice(mockedBaseAggregator, pool)
+
                 await addOrder(fixture, alice, 10, 2000, 0, 150000)
                 // bob swap, alice get maker fee
                 await q2bExactInput(fixture, bob, 3000, baseToken.address)
@@ -365,42 +367,36 @@ describe("Vault test", () => {
             })
 
             it("trader has positive realized PnL", async () => {
+                await syncIndexToMarketPrice(mockedBaseAggregator, pool)
+
                 // bob long, so alice can have positive realized PnL after closing position
                 await q2bExactInput(fixture, bob, 1000, baseToken.address)
-
-                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
-                    return [0, parseUnits("180", 6), 0, 0, 0]
-                })
 
                 await forwardBothTimestamps(clearingHouse, 360)
 
                 await closePosition(fixture, alice)
 
-                // realized PnL (including funding payment): 13.875441
-                // settlement token value: 1000 + 13.875441 = 1013.875441
-                expect(await vault.getSettlementTokenValue(alice.address)).to.be.closeTo(
-                    parseUnits("1013.875441", usdcDecimals),
-                    // there can be a huge imprecision, thus giving an about 0.05% fault tolerance range
-                    parseUnits("0.5", usdcDecimals).toNumber(),
+                // realized PnL (including funding payment): 12.569457
+                // settlement token value: 1000 + 12.569457 = 1012.569457
+                expect(await vault.getSettlementTokenValue(alice.address)).to.be.eq(
+                    parseUnits("1012.569457", usdcDecimals),
                 )
             })
 
             it("trader has negative realized PnL", async () => {
+                await syncIndexToMarketPrice(mockedBaseAggregator, pool)
+
                 // bob short, so alice can have negative realized PnL after closing position
                 await b2qExactOutput(fixture, bob, 1000, baseToken.address)
-
-                mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
-                    return [0, parseUnits("180", 6), 0, 0, 0]
-                })
 
                 await forwardBothTimestamps(clearingHouse, 360)
 
                 await closePosition(fixture, alice)
 
-                // realized PnL (including funding payment): -131.456293
-                // settlement token value: 1000 - 131.456293 = 868.543707
+                // realized PnL (including funding payment): -132.53927
+                // settlement token value: 1000 - 132.53927 = 867.460730
                 expect(await vault.getSettlementTokenValue(alice.address)).to.be.eq(
-                    parseUnits("868.543706", usdcDecimals),
+                    parseUnits("867.460730", usdcDecimals),
                 )
             })
         })
@@ -441,25 +437,24 @@ describe("Vault test", () => {
             it("trader is both maker & taker", async () => {
                 await addOrder(fixture, alice, 10, 2000, 0, 150000)
                 // bob swap, alice get maker fee
-                await q2bExactInput(fixture, bob, 3000, baseToken.address)
+                await q2bExactInput(fixture, bob, 300, baseToken.address)
 
-                // market price: 175.63239005
+                // market price: 164.605506117068038532
                 mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
                     return [0, parseUnits("180", 6), 0, 0, 0]
                 })
 
                 await forwardBothTimestamps(clearingHouse, 360)
 
-                // total position size: 18.52739798
-                // total quote balance in order: 60.47455739
-                // unrealized PnL: 18.52739798 * 180 - 3000 + 60.47455739 = 395.406193
-                // pending maker fee: 0.61085412
-                // pending funding payment: -0.36089388
-                // settlement token value: 0.61085412 - (-0.36089388) + 395.406193 = 396.377941
+                // total position size: 18.84750169711406076
+                // total open notional: -2993.952544261279477388
+                // unrealized PnL: 18.84750169711406076 * 180 -2993.952544261279477388 = 398.5977612193
+                // pending maker fee: 0.054976870352004751
+                // pending funding payment: -1.219374926076949977
+                // settlement token value: 0.054976870352004751 - (-1.219374926076949977) + 398.5977612193 = 399.872113
                 expect(await vault.getSettlementTokenValue(alice.address)).to.be.closeTo(
-                    parseUnits("396.377941", usdcDecimals),
-                    // there can be a huge imprecision, thus giving an about 0.05% fault tolerance range
-                    parseUnits("0.15", usdcDecimals).toNumber(),
+                    parseUnits("399.872113", usdcDecimals),
+                    parseUnits("0.1", usdcDecimals).toNumber(),
                 )
             })
         })
@@ -507,67 +502,69 @@ describe("Vault test", () => {
         it("trader is both maker & taker", async () => {
             await addOrder(fixture, alice, 10, 2000, 0, 150000)
             // bob swap, alice get maker fee
-            await q2bExactInput(fixture, bob, 3000, baseToken.address)
+            await q2bExactInput(fixture, bob, 300, baseToken.address)
 
-            // market price: 175.63239005
+            // market price: 164.605506117068038532
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
                 return [0, parseUnits("180", 6), 0, 0, 0]
             })
 
             await forwardBothTimestamps(clearingHouse, 360)
 
-            // total position size: 18.52739798
-            // total quote balance in order: 60.47455739
-            // unrealized PnL: 18.52739798 * 180 - 3000 + 60.47455739 = 395.406193
-            // pending maker fee: 0.61085412
-            // pending funding payment: -0.39209485
-            // account value: 500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7 + 0.61085412 - (-0.39209485) + 395.406193 = 1386.40914197
+            // total position size: 18.84750169711406076
+            // total open notional: -2993.952544261279477388
+            // unrealized PnL: 18.84750169711406076 * 180 -2993.952544261279477388 = 398.5977612193
+            // pending maker fee: 0.054976870352004751
+            // pending funding payment: -1.230993742106468956
+            // account value: (500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7) + 0.054976870352004751 - (-1.219374926076949977) + 398.5977612193 = 1389.872113
             expect(await vault.getAccountValue(alice.address)).to.be.closeTo(
-                parseUnits("1386.409141", usdcDecimals),
+                parseUnits("1389.872113", usdcDecimals),
                 // there can be a huge imprecision, thus giving an about 0.05% fault tolerance range
                 parseUnits("0.5", usdcDecimals).toNumber(),
             )
         })
 
         it("trader has positive realized PnL", async () => {
+            await syncIndexToMarketPrice(mockedBaseAggregator, pool)
             // bob long, so alice can have positive realized PnL after closing position
             await q2bExactInput(fixture, bob, 1000, baseToken.address)
 
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
-                return [0, parseUnits("180", 6), 0, 0, 0]
+                return [0, parseUnits("170", 6), 0, 0, 0]
             })
 
             await forwardBothTimestamps(clearingHouse, 360)
 
             await closePosition(fixture, alice)
 
-            // realized PnL(including funding): 13.905703
-            // account value: 500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7 + 13.905703 = 1003.905703
+            // realized PnL(including funding): 13.096488
+            // account value: 500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7 + 13.096488 = 1003.096488
             expect(await vault.getAccountValue(alice.address)).to.be.closeTo(
-                parseUnits("1003.905703", usdcDecimals),
+                parseUnits("1003.096488", usdcDecimals),
                 // there can be a huge imprecision, thus giving an about 0.05% fault tolerance range
-                parseUnits("0.4", usdcDecimals).toNumber(),
+                parseUnits("0.5", usdcDecimals).toNumber(),
             )
         })
 
         it("trader has negative realized PnL", async () => {
+            await syncIndexToMarketPrice(mockedBaseAggregator, pool)
             // bob short, so alice can have negative realized PnL after closing position
             await b2qExactOutput(fixture, bob, 1000, baseToken.address)
 
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
-                return [0, parseUnits("180", 6), 0, 0, 0]
+                return [0, parseUnits("160", 6), 0, 0, 0]
             })
 
             await forwardBothTimestamps(clearingHouse, 360)
 
             await closePosition(fixture, alice)
 
-            // realized PnL(including funding): -131.424819
-            // account value: 500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7 - 131.424819 = 858.575181
+            // realized PnL(including funding): -132.803228
+            // account value: 500 + 0.1 * 3000 * 0.7 + 0.01 * 40000 * 0.7 - 132.803228 = 857.196772
             expect(await vault.getAccountValue(alice.address)).to.be.closeTo(
-                parseUnits("858.575181", usdcDecimals),
+                parseUnits("857.196772", usdcDecimals),
                 // there can be a huge imprecision, thus giving an about 0.05% fault tolerance range
-                parseUnits("0.4", usdcDecimals).toNumber(),
+                parseUnits("0.5", usdcDecimals).toNumber(),
             )
         })
     })

--- a/test/vault/Vault.withdraw.test.ts
+++ b/test/vault/Vault.withdraw.test.ts
@@ -86,7 +86,7 @@ describe("Vault withdraw test", () => {
         await wbtc.mint(alice.address, parseUnits("200", await wbtc.decimals()))
 
         // bob mint and add liquidity
-        await usdc.mint(bob.address, parseUnits("1000", usdcDecimals))
+        await usdc.mint(bob.address, parseUnits("10000", usdcDecimals))
     })
 
     describe("withdraw check", async () => {
@@ -95,8 +95,8 @@ describe("Vault withdraw test", () => {
             await deposit(alice, vault, 10000, usdc)
 
             // bob deposit and add liquidity
-            await deposit(bob, vault, 1000, usdc)
-            await addOrder(fixture, bob, 10, 1500, 0, 150000)
+            await deposit(bob, vault, 10000, usdc)
+            await addOrder(fixture, bob, 100, 15000, 0, 150000)
 
             // alice swap
             await q2bExactInput(fixture, alice, 100)


### PR DESCRIPTION
Fixes tests:
- Vault withdraw test
- Vault test
- Vault liquidationGetter test
- Vault liquidate test (assume zero IF fee)
- ClearingHouse verify accounting
- ClearingHouse takeOver (liquidate)
- ClearingHouse.swap
- Clearinghouse StopMarket