### PR TITLE
Fix test for price band - 2

### DIFF
--- a/test/accountBalance/AccountBalance.spec.ts
+++ b/test/accountBalance/AccountBalance.spec.ts
@@ -188,13 +188,13 @@ describe("AccountBalance", () => {
                 deadline: ethers.constants.MaxUint256,
             })
 
-            // bob short 1 base (baseToken2)
+            // bob short 0.1 base (baseToken2)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken2.address,
                 isBaseToQuote: true,
                 isExactInput: true,
                 oppositeAmountBound: 0,
-                amount: parseEther("1"),
+                amount: parseEther("0.1"),
                 sqrtPriceLimitX96: 0,
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
@@ -202,13 +202,13 @@ describe("AccountBalance", () => {
 
             expect(await accountBalance.getBaseTokens(bob.address)).be.deep.eq([baseToken2.address])
 
-            // bob long 100 quote (baseToken)
+            // bob long 10 quote (baseToken)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: false,
                 isExactInput: true,
                 oppositeAmountBound: 0,
-                amount: parseEther("100"),
+                amount: parseEther("10"),
                 sqrtPriceLimitX96: 0,
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,

--- a/test/clearingHouse/ClearingHouse.7494.badDebtAttack.test.ts
+++ b/test/clearingHouse/ClearingHouse.7494.badDebtAttack.test.ts
@@ -177,9 +177,17 @@ describe("ClearingHouse 7494 bad debt attack", () => {
         await testNoProfit(false)
     })
 
-    it("end price $1.44 (spread more than 10%)", async () => {
-        await manipulatePrice(1.44)
-        // account 2 can not add liquidity
-        await testBlockBadDebtAttack()
+    it("can not manipulate end price $1.44 (spread more than 10%)", async () => {
+        let canManipulated = true
+
+        try {
+            await manipulatePrice(1.44)
+        } catch (e: any) {
+            if (e.message.includes("EX_OPSAS")) {
+                canManipulated = false
+            }
+        }
+
+        expect(canManipulated).to.eq(false)
     })
 })

--- a/test/clearingHouse/ClearingHouse.7494.badDebtAttack.test.ts
+++ b/test/clearingHouse/ClearingHouse.7494.badDebtAttack.test.ts
@@ -183,7 +183,7 @@ describe("ClearingHouse 7494 bad debt attack", () => {
         try {
             await manipulatePrice(1.44)
         } catch (e: any) {
-            if (e.message.includes("EX_OPSAS")) {
+            if (e.message.includes("EX_OPB")) {
                 canManipulated = false
             }
         }

--- a/test/clearingHouse/ClearingHouse.accounting.xyk.test.ts
+++ b/test/clearingHouse/ClearingHouse.accounting.xyk.test.ts
@@ -523,7 +523,6 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
             await q2bExactInput(fixture, taker, 2.1234)
             await forwardBothTimestamps(clearingHouse, 300)
 
-            console.log((await exchange.getSqrtMarkTwapX96(baseToken.address, 0)).toString())
             // index price change and funding rate reversed
             // market price: 10.042470530144136
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
@@ -600,7 +599,6 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
         it("bad debt", async () => {
             // maker add liquidity
             await addOrder(fixture, maker, 100, 10000, lowerTick, upperTick)
-            console.log(0)
 
             // taker open, quote input: 300, base output: 26.06426925
             // set index price higher, let taker can open long position

--- a/test/clearingHouse/ClearingHouse.accounting.xyk.test.ts
+++ b/test/clearingHouse/ClearingHouse.accounting.xyk.test.ts
@@ -219,18 +219,18 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
     }
 
     it("taker's balance after = taker's balance before + realizedPnl", async () => {
-        await takerLongExactInput(100)
+        await takerLongExactInput(10)
         await takerCloseEth()
         const freeCollateral = await vault.getFreeCollateral(taker.address)
 
         await vault.connect(taker).withdraw(collateral.address, freeCollateral.toString())
 
-        // 100 - 0.199900000000000024 ~= 99.800100
-        expect(await collateral.balanceOf(taker.address)).eq(parseUnits("99.800099", 6))
+        // 100 - 0.0199900000000000024 ~= 99.98001
+        expect(await collateral.balanceOf(taker.address)).eq(parseUnits("99.980009", 6))
     })
 
     it("won't emit funding payment settled event since the time is freeze", async () => {
-        const openPositionTx = await takerLongExactInput(100)
+        const openPositionTx = await takerLongExactInput(10)
         await expect(openPositionTx).not.to.emit(clearingHouse, "FundingPaymentSettled")
         const closePositionTx = await takerCloseEth()
         await expect(closePositionTx).not.to.emit(clearingHouse, "FundingPaymentSettled")
@@ -249,7 +249,7 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
         })
 
         it("taker long exact input", async () => {
-            await takerLongExactInput(100)
+            await takerLongExactInput(10)
             expect(await getTakerMakerPositionSizeDelta()).be.closeTo(BigNumber.from(0), 2)
 
             await takerCloseEth()
@@ -279,7 +279,7 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
         })
 
         it("taker short exact output", async () => {
-            await takerShortExactOutput(100)
+            await takerShortExactOutput(10)
             expect(await getTakerMakerPositionSizeDelta()).be.closeTo(BigNumber.from(0), 2)
 
             await takerCloseEth()
@@ -290,28 +290,28 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
     })
 
     it("has same realizedPnl once everyone close their position", async () => {
-        const openPositionTx = await takerLongExactInput(100)
+        const openPositionTx = await takerLongExactInput(10)
         await expect(openPositionTx).to.emit(clearingHouse, "PositionChanged").withArgs(
             taker.address, // trader
             baseToken.address, // baseToken
-            "9082643876716065096", // exchangedPositionSize
-            "-99899999999999999999", // exchangedPositionNotional
-            "100000000000000001", // fee
-            "-100000000000000000000", // openNotional
+            "989118704145585599", // exchangedPositionSize
+            "-9989999999999999999", // exchangedPositionNotional
+            "10000000000000001", // fee
+            "-10000000000000000000", // openNotional
             "0", // realizedPnl
-            "275570539067715219511427190085", // sqrtPriceAfterX96
+            "253044357444314660018820777121", // sqrtPriceAfterX96
         )
 
         const closePositionTx = await takerCloseEth()
         await expect(closePositionTx).to.emit(clearingHouse, "PositionChanged").withArgs(
             taker.address, // trader
             baseToken.address, // baseToken
-            "-9082643876716065096", // exchangedPositionSize
-            "99899999999999999978", // exchangedPositionNotional
-            "99900000000000001", // fee
+            "-989118704145585599", // exchangedPositionSize
+            "9989999999999999988", // exchangedPositionNotional
+            "9990000000000001", // fee
             "0", // openNotional
-            "-199900000000000023", // realizedPnl
-            "250541448375047931191432615077", // sqrtPriceAfterX96
+            "-19990000000000013", // realizedPnl
+            "250541448375047931188927200593", // sqrtPriceAfterX96
         )
 
         // maker remove liquidity
@@ -332,16 +332,16 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
             quoteToken.address,
             lowerTick,
             upperTick,
-            "-99999999999999999982", // return base
-            "-1000000000000000000019", // return quote
+            "-99999999999999999983", // return base
+            "-1000000000000000000009", // return quote
             "-316227766016837933205", // liquidity
-            "179909999999999999", // fee (100000000000000001 + 99900000000000001) * 90%
+            "17990999999999999", // fee (10000000000000001 + 9990000000000001) * 90%
         )
 
         // ifOwedRealizedPnl + taker's realizedPnl from event + maker's quoteFee from event ~= 0
         const ifOwedRealizedPnl = (await accountBalance.getPnlAndPendingFee(insuranceFund.address))[0]
         expect(
-            ifOwedRealizedPnl.add(BigNumber.from("179909999999999999")).sub(BigNumber.from("199900000000000024")),
+            ifOwedRealizedPnl.add(BigNumber.from("17990999999999999")).sub(BigNumber.from("19990000000000013")),
         ).be.closeTo(BigNumber.from("0"), 25)
     })
 
@@ -372,8 +372,8 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
         })
 
         it("single take", async () => {
-            // taker open, taker fee 100 * 0.1% = 0.1
-            await q2bExactInput(fixture, taker, 100)
+            // taker open, taker fee 10 * 0.1% = 0.01
+            await q2bExactInput(fixture, taker, 10)
 
             // maker move liquidity
             await removeAllOrders(fixture, maker)
@@ -422,7 +422,7 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
 
         it("multiple makers with multiple takers", async () => {
             // taker, taker2, taker3 open
-            await q2bExactInput(fixture, taker, 50.456)
+            await q2bExactInput(fixture, taker, 5.456)
             await q2bExactInput(fixture, taker2, 0.123)
             await b2qExactInput(fixture, taker3, 0.987)
 
@@ -453,11 +453,11 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
 
             // maker1 and maker2 add liquidity
             // current tick = 23027
-            await addOrder(fixture, maker, 2, 200, 23000, 24000)
-            await addOrder(fixture, maker2, 2, 200, 25000, 27000)
+            await addOrder(fixture, maker, 2, 200, 23000, 23600)
+            await addOrder(fixture, maker2, 2, 200, 24000, 27000)
 
-            // end tick = 25689
-            await q2bExactInput(fixture, taker, 30)
+            // end tick = 23445
+            await q2bExactInput(fixture, taker, 15)
 
             // taker close position
             await closePosition(fixture, taker)
@@ -472,8 +472,8 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
         })
 
         it("taker takes profit", async () => {
-            // taker open, taker fee 100 * 0.1% = 0.1
-            await q2bExactInput(fixture, taker, 100)
+            // taker open, taker fee 10 * 0.1% = 0.01
+            await q2bExactInput(fixture, taker, 10)
 
             // maker move
             await removeAllOrders(fixture, maker)
@@ -481,7 +481,7 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
             await addOrder(fixture, maker, 100, 1000, lowerTick + 2000, upperTick - 2000)
 
             // taker reduce position
-            await b2qExactOutput(fixture, taker, 30)
+            await b2qExactOutput(fixture, taker, 3)
 
             // taker withdraw
             const takerFreeCollateral = await vault.getFreeCollateral(taker.address)
@@ -520,16 +520,18 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
 
         it("funding payment arbitrage", async () => {
             // taker open
-            await q2bExactInput(fixture, taker, 20.1234)
+            await q2bExactInput(fixture, taker, 2.1234)
             await forwardBothTimestamps(clearingHouse, 300)
 
+            console.log((await exchange.getSqrtMarkTwapX96(baseToken.address, 0)).toString())
             // index price change and funding rate reversed
+            // market price: 10.042470530144136
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
-                return [0, parseUnits("15", 6), 0, 0, 0]
+                return [0, parseUnits("11", 6), 0, 0, 0]
             })
 
             // taker open reverse
-            await b2qExactOutput(fixture, taker, 30)
+            await b2qExactOutput(fixture, taker, 3)
             await forwardBothTimestamps(clearingHouse, 300)
 
             // taker close
@@ -543,16 +545,16 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
             // maker add liquidity
             await addOrder(fixture, maker, 100, 10000, lowerTick, upperTick)
 
-            // taker open
-            await q2bExactInput(fixture, taker, 150)
+            // taker open short
+            await b2qExactOutput(fixture, taker, 100)
 
             // set index price to let taker underwater
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
-                return [0, parseUnits("0.1", 6), 0, 0, 0]
+                return [0, parseUnits("20", 6), 0, 0, 0]
             })
 
             // liquidate taker
-            while ((await accountBalance.getTotalPositionSize(taker.address, baseToken.address)).gt(0)) {
+            while (!(await accountBalance.getTotalPositionSize(taker.address, baseToken.address)).eq(0)) {
                 await clearingHouse
                     .connect(taker2)
                     ["liquidate(address,address,int256)"](taker.address, baseToken.address, 0)
@@ -573,7 +575,7 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
             await addOrder(fixture, maker, 100, 10000, lowerTick, upperTick)
 
             // taker open
-            await q2bExactInput(fixture, taker, 150)
+            await q2bExactInput(fixture, taker, 90)
 
             // set index price to let taker pay funding fee
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
@@ -582,7 +584,7 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
 
             // taker pays funding
             while ((await clearingHouse.getAccountValue(taker.address)).gt(0)) {
-                await forwardBothTimestamps(clearingHouse, 3000)
+                await forwardBothTimestamps(clearingHouse, 30000)
 
                 await clearingHouse.connect(taker).settleAllFunding(taker.address)
             }
@@ -598,8 +600,13 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
         it("bad debt", async () => {
             // maker add liquidity
             await addOrder(fixture, maker, 100, 10000, lowerTick, upperTick)
+            console.log(0)
 
             // taker open, quote input: 300, base output: 26.06426925
+            // set index price higher, let taker can open long position
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("15", 6), 0, 0, 0]
+            })
             await q2bExactInput(fixture, taker, 300)
 
             // maker move liquidity
@@ -607,13 +614,13 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
             await syncIndexToMarketPrice(mockedBaseAggregator, pool)
             await addOrder(fixture, maker, 30, 10000, lowerTick, upperTick)
 
-            // taker cannot close position (quote output: 184.21649272), but can be liquidated
-            await expect(closePosition(fixture, taker)).to.be.revertedWith("CH_NEMRM")
-
             // set index price to let taker be liquidated
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
                 return [0, parseUnits("4", 6), 0, 0, 0]
             })
+
+            // taker cannot close position (quote output: 184.21649272), but can be liquidated
+            await expect(closePosition(fixture, taker)).to.be.revertedWith("CH_NEMRM")
 
             await clearingHouse
                 .connect(taker2)
@@ -631,7 +638,7 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
             await addOrder(fixture, maker, 100, 10000, lowerTick, upperTick)
 
             // taker open
-            await q2bExactInput(fixture, taker, 150)
+            await q2bExactInput(fixture, taker, 90)
         })
     })
 
@@ -643,21 +650,33 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
             await mintAndDeposit(fixture, maker, 10000)
 
             // maker add liquidity, current tick 23027
-            await addOrder(fixture, maker, 10, 1000, 22000, 24000)
+            await addOrder(fixture, maker, 10, 100, 22000, 24000)
 
-            // set index price to let taker pay funding fee
-            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
-                return [0, parseUnits("4", 6), 0, 0, 0]
-            })
             // prepare collateral
             await mintAndDeposit(fixture, taker, 1000)
 
             // there is only around 1000 USD in the pool
-            // taker swap all liquidity, current tick in pool becomes to MAX_TICK-1 (887271)
-            await q2bExactInput(fixture, taker, 2000)
+            // taker swap all liquidity, current tick in pool is over 24000 (the upper tick of order)
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("11", 6), 0, 0, 0]
+            })
+            await clearingHouse.connect(taker).openPosition({
+                baseToken: baseToken.address,
+                isBaseToQuote: false,
+                isExactInput: true,
+                amount: parseEther("2000"),
+                oppositeAmountBound: 0,
+                deadline: ethers.constants.MaxUint256,
+                // swap to tick 24060
+                sqrtPriceLimitX96: BigNumber.from("26382122004").mul("10000000000000000000"),
+                referralCode: ethers.constants.HashZero,
+            })
 
-            // failed to swap again
-            await expect(q2bExactInput(fixture, taker2, 100)).to.revertedWith("SPL")
+            const { tick } = await pool.slot0()
+            expect(tick).to.be.eq(24060)
+
+            // failed to swap again, there is no liquidity in pool
+            await expect(q2bExactInput(fixture, taker2, 100)).to.revertedWith("CH_F0S")
 
             // maker's fee are collected
             const fee = (
@@ -673,21 +692,14 @@ describe("ClearingHouse accounting verification in xyk pool", () => {
             ).fee
             expect(fee).to.be.gt("0")
 
-            await forwardBothTimestamps(clearingHouse, 200)
-            expect(await exchange.getPendingFundingPayment(taker.address, baseToken.address)).to.be.gt("0")
-
-            await clearingHouse.connect(taker).settleAllFunding(taker.address)
-
-            await forwardBothTimestamps(clearingHouse, 200)
-            expect(await exchange.getPendingFundingPayment(taker.address, baseToken.address)).to.be.gt("0")
-
-            // Due to current tick hits the MAX_TICK-1, that means the mark price will be super large.
-            // Can not add more liquidity since it will be failed by price spread checking.
             // Can only open opposite positions
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("10", 6), 0, 0, 0]
+            })
             await closePosition(fixture, taker, 0, baseToken.address)
 
             // taker2 can keep on swapping
-            await q2bExactInput(fixture, taker2, 100)
+            await q2bExactInput(fixture, taker2, 1)
         })
     })
 })

--- a/test/clearingHouse/ClearingHouse.cancelExecessOrders.test.ts
+++ b/test/clearingHouse/ClearingHouse.cancelExecessOrders.test.ts
@@ -180,6 +180,12 @@ describe("ClearingHouse cancelExcessOrders", () => {
             const amount = parseUnits("10", await collateral.decimals())
             await collateral.transfer(carol.address, amount)
             await deposit(carol, vault, 10, collateral)
+
+            // set index price to near market price (alice tick range is 92200 ~ 92400)
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("10101", 6), 0, 0, 0]
+            })
+
             // carol position size: 0 -> 0.000490465148677081
             // alice position size: 0 -> -0.000490465148677081
             await clearingHouse.connect(carol).openPosition({
@@ -234,7 +240,13 @@ describe("ClearingHouse cancelExcessOrders", () => {
             await deposit(carol, vault, 20, collateral)
         })
 
+        // TODO: need to rewrite this test based on new price protected design
         it("bob should get realizedPnl after cancel orders", async () => {
+            // set index price to near market price (alice tick range is 92200 ~ 92400)
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("10101", 6), 0, 0, 0]
+            })
+
             // 1. bob opens a long position, position size: 0.000490465148677081
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
@@ -259,11 +271,18 @@ describe("ClearingHouse cancelExcessOrders", () => {
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
                 return [0, parseUnits("100", 6), 0, 0, 0]
             })
-            await vault.connect(bob).withdraw(collateral.address, parseUnits("1980", await collateral.decimals()))
+
+            await vault
+                .connect(bob)
+                .withdraw(collateral.address, parseUnits("1984.553951", await collateral.decimals()))
 
             // 4. carol opens a long position and bob incurs a short position
             // carol position size: 0 -> 0.000961493924477756
             // bob position size: 0 -> -0.000961493924477756
+            // set index price higher to let carol can open a long position
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("10101", 6), 0, 0, 0]
+            })
             await q2bExactInput(fixture, carol, "10", baseToken.address)
 
             mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {

--- a/test/clearingHouse/ClearingHouse.closePosition.test.ts
+++ b/test/clearingHouse/ClearingHouse.closePosition.test.ts
@@ -9,12 +9,14 @@ import {
     TestClearingHouse,
     TestERC20,
     TestExchange,
+    UniswapV3Pool,
     Vault,
 } from "../../typechain"
 import { addOrder, closePosition, q2bExactInput, q2bExactOutput } from "../helper/clearingHouseHelper"
 import { initMarket } from "../helper/marketHelper"
 import { deposit } from "../helper/token"
 import { forwardBothTimestamps } from "../shared/time"
+import { encodePriceSqrt } from "../shared/utilities"
 import { ClearingHouseFixture, createClearingHouseFixture } from "./fixtures"
 
 describe("ClearingHouse closePosition", () => {
@@ -31,6 +33,7 @@ describe("ClearingHouse closePosition", () => {
     let mockedBaseAggregator: MockContract
     let lowerTick = "50000" // 148.3760629231
     let upperTick = "50200" // 151.3733068587
+    let pool: UniswapV3Pool
 
     beforeEach(async () => {
         fixture = await loadFixture(createClearingHouseFixture())
@@ -42,6 +45,7 @@ describe("ClearingHouse closePosition", () => {
         collateral = fixture.USDC
         baseToken = fixture.baseToken
         mockedBaseAggregator = fixture.mockedBaseAggregator
+        pool = fixture.pool
 
         const collateralDecimals = await collateral.decimals()
         // mint
@@ -104,13 +108,20 @@ describe("ClearingHouse closePosition", () => {
             })
 
             // taker pays 0.06151334175725025 / 0.99 = 0.06213468864 quote to pay back 0.0004084104205 base
-            await clearingHouse.connect(bob).closePosition({
+            // using original sqrtPriceX96 to avoid over price limit
+            await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
-                sqrtPriceLimitX96: 0,
+                isBaseToQuote: false,
+                isExactInput: false,
                 oppositeAmountBound: 0,
+                amount: parseEther("0.0004084104205"),
+                sqrtPriceLimitX96: encodePriceSqrt("151.373306858723226652", "1"),
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
+
+            // bob has dust due to uniswapV3
+            const bobDust = 153
 
             // assure that the position of the taker is closed completely, and so is maker's position
             expect(await accountBalance.getTotalPositionSize(bob.address, baseToken.address)).to.eq(0)
@@ -118,7 +129,7 @@ describe("ClearingHouse closePosition", () => {
 
             // taker sells all quote, making netQuoteBalance == 0
             const [bobNetQuoteBalance, bobFee] = await accountBalance.getNetQuoteBalanceAndPendingFee(bob.address)
-            expect(bobNetQuoteBalance.add(bobFee)).to.eq(0)
+            expect(bobNetQuoteBalance.add(bobFee)).to.be.closeTo("0", bobDust)
 
             // maker gets 0.06151334175725025 * 0.01 + 0.06213468864 * 0.01 = 0.001236480304
             const pnlMaker = parseEther("0.001236480304009373")
@@ -131,7 +142,7 @@ describe("ClearingHouse closePosition", () => {
             // for maker, it's unrealizedPnl, thus getting the second element [1] of the array
             let owedOrUnrealizedPnlMaker = (await accountBalance.getPnlAndPendingFee(alice.address))[1]
             let feeMaker = (await accountBalance.getPnlAndPendingFee(alice.address))[2]
-            expect(owedRealizedPnlTaker.abs()).to.be.closeTo(owedOrUnrealizedPnlMaker.add(feeMaker).abs(), 10)
+            expect(owedRealizedPnlTaker.abs()).to.be.closeTo(owedOrUnrealizedPnlMaker.add(feeMaker).abs(), bobDust)
             expect(owedOrUnrealizedPnlMaker.add(feeMaker)).to.eq(pnlMaker)
 
             await clearingHouse.connect(alice).removeLiquidity({
@@ -186,13 +197,20 @@ describe("ClearingHouse closePosition", () => {
                 referralCode: ethers.constants.HashZero,
             })
 
-            await clearingHouse.connect(carol).closePosition({
+            // using original sqrtPriceX96 to avoid over price limit
+            await clearingHouse.connect(carol).openPosition({
                 baseToken: baseToken.address,
-                sqrtPriceLimitX96: 0,
+                isBaseToQuote: false,
+                isExactInput: false,
                 oppositeAmountBound: 0,
+                amount: base.sub(base.div(2)),
+                sqrtPriceLimitX96: encodePriceSqrt("151.373306858723226652", "1"),
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
+
+            // carol has dust due to uniswapV3
+            const carolDust = 153
 
             // assure that position of takers are closed completely, and so is maker's position
             expect(await accountBalance.getTotalPositionSize(bob.address, baseToken.address)).to.eq(0)
@@ -205,7 +223,7 @@ describe("ClearingHouse closePosition", () => {
             const [aliceNetQuoteBalance, aliceFee] = await accountBalance.getNetQuoteBalanceAndPendingFee(alice.address)
 
             expect(bobNetQuoteBalance).to.eq(0)
-            expect(carolNetQuoteBalance).to.eq(0)
+            expect(carolNetQuoteBalance).to.be.closeTo("0", carolDust)
 
             // maker gets 0.06151334175725025 * 0.01 + 0.06213468864 * 0.01 = 0.001236480304
             const pnlMaker = parseEther("0.001236480304009373")
@@ -223,7 +241,7 @@ describe("ClearingHouse closePosition", () => {
             let feeMaker = (await accountBalance.getPnlAndPendingFee(alice.address))[2]
             expect(owedRealizedPnlBob.add(owedRealizedPnlCarol).abs()).to.be.closeTo(
                 owedOrUnrealizedPnlMaker.add(feeMaker).abs(),
-                10,
+                carolDust,
             )
             expect(owedOrUnrealizedPnlMaker.add(feeMaker)).to.eq(pnlMaker)
 
@@ -659,10 +677,13 @@ describe("ClearingHouse closePosition", () => {
                 referralCode: ethers.constants.HashZero,
             })
 
-            await clearingHouse.connect(bob).closePosition({
+            await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
-                sqrtPriceLimitX96: 0,
+                isBaseToQuote: false,
+                isExactInput: false,
                 oppositeAmountBound: 0,
+                amount: parseEther("0.0004084104205"),
+                sqrtPriceLimitX96: encodePriceSqrt(initPrice, 1),
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
@@ -691,7 +712,7 @@ describe("ClearingHouse closePosition", () => {
             await addOrder(fixture, alice, 10, 1000, lowerTick, upperTick)
 
             // bob swap to let alice has maker impermanent position
-            await q2bExactInput(fixture, bob, 100)
+            await q2bExactInput(fixture, bob, 10)
 
             // alice has maker position
             const totalPositionSize = await accountBalance.getTotalPositionSize(alice.address, baseToken.address)
@@ -700,25 +721,23 @@ describe("ClearingHouse closePosition", () => {
             expect(makerPositionSize).to.be.lt(0)
             expect(takerPositionSize).to.be.eq(0)
 
-            // alice has taker position, swap 100 quote to 0.49 base
-            await q2bExactInput(fixture, alice, 100)
+            // alice has taker position, swap 10 quote to 0.06350274755 base
+            await q2bExactInput(fixture, alice, 10)
             expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.deep.eq(
-                "496742576407532823",
+                "63502747547593254",
             )
             // total position unchanged
-            expect(await accountBalance.getTotalPositionSize(alice.address, baseToken.address)).to.be.closeTo(
+            expect(await accountBalance.getTotalPositionSize(alice.address, baseToken.address)).to.be.eq(
                 totalPositionSize,
-                1,
             )
 
             // alice close position
             await closePosition(fixture, alice)
             // taker position size is 0
-            expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.closeTo("0", 1)
+            expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.eq(0)
             // total position(only maker) unchanged
-            expect(await accountBalance.getTotalPositionSize(alice.address, baseToken.address)).to.be.closeTo(
+            expect(await accountBalance.getTotalPositionSize(alice.address, baseToken.address)).to.be.eq(
                 makerPositionSize,
-                1,
             )
         })
 
@@ -726,10 +745,10 @@ describe("ClearingHouse closePosition", () => {
             await addOrder(fixture, alice, 10, 1000, lowerTick, upperTick)
 
             // bob swap, alice has maker impermanent position
-            await q2bExactInput(fixture, bob, 100)
+            await q2bExactInput(fixture, bob, 10)
 
             // alice has maker position and 0 taker position
-            expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.closeTo("0", 1)
+            expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.eq(0)
             expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.eq(0)
 
             // alice close position
@@ -738,29 +757,33 @@ describe("ClearingHouse closePosition", () => {
 
         it("can not partial close if over price limit", async () => {
             // alice add liquidity
-            await addOrder(fixture, alice, 10, 1000, lowerTick, upperTick)
+            await addOrder(fixture, alice, 10, 1510, lowerTick, upperTick)
+
+            // mock index price higher, so that taker can push more market price
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("165", 6), 0, 0, 0]
+            })
 
             // bob swap let alice has maker position
+            // after bob swap, market price: 153.36, index price: 165, spread: -7.7%
             await q2bExactInput(fixture, bob, 10)
 
             // alice swap
-            await q2bExactOutput(fixture, alice, 5)
+            // after alice swap, market price: 170.095, index price: 165, spread: 3.37%
+            await q2bExactOutput(fixture, alice, 0.5)
 
-            expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.deep.eq(
-                parseEther("5"),
+            expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.eq(
+                parseEther("0.5"),
             )
 
             // alice partial close position, forward timestamp to bypass over price limit timestamp check
             await forwardBothTimestamps(clearingHouse, 3000)
 
             // set MaxTickCrossedWithinBlock so that trigger over price limit
-            await exchange.setMaxTickCrossedWithinBlock(baseToken.address, 1000)
-            await expect(closePosition(fixture, alice)).to.be.revertedWith("EX_OPLAS")
+            await exchange.setMaxTickCrossedWithinBlock(baseToken.address, 250)
 
-            // // expect partial close 5 * 25% = 1.25
-            // expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.deep.eq(
-            //     parseEther("3.75"),
-            // )
+            // after alice partial close, market price: 165.664, index price: 165, spread: 0.44% (nor over price band limit)
+            await expect(closePosition(fixture, alice)).to.be.revertedWith("EX_OPLAS")
         })
     })
 })

--- a/test/clearingHouse/ClearingHouse.customiseFee.test.ts
+++ b/test/clearingHouse/ClearingHouse.customiseFee.test.ts
@@ -993,6 +993,11 @@ describe("ClearingHouse customized fee", () => {
         it("long and exact in, cross 2 ranges, 3 makers get their fees", async () => {
             const totalFee = parseEther("20").add(2) // fee = 1000 * 0.01 + 2wei (rounding up)
 
+            // mock index price higher, let taker open a large long position
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("198.687932", 6), 0, 0, 0]
+            })
+
             // taker open a large position, crossed 2 ranges
             // making the price becomes ~= 198.2516818352, tick ~= 52898.018163
             await expect(
@@ -1071,6 +1076,11 @@ describe("ClearingHouse customized fee", () => {
 
         it("short and exact out, cross 2 ranges, 3 makers get their fees", async () => {
             const totalFee = parseEther("20.202020202020202022") // fee = 2000 / 0.99 * 0.01
+
+            // mock index price lower, let taker open a large short position
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("109.710327", 6), 0, 0, 0]
+            })
 
             // taker open a large position, crossed 2 ranges
             await expect(

--- a/test/clearingHouse/ClearingHouse.getNetQuoteBalance.test.ts
+++ b/test/clearingHouse/ClearingHouse.getNetQuoteBalance.test.ts
@@ -131,31 +131,31 @@ describe("ClearingHouse getNetQuoteBalanceAndPendingFee", () => {
             })
 
             // taker swaps
-            // base: 1
-            // B2QFee: CH actually shorts 1 / 0.99 = 1.0101010101 and get 63.7442741703 quote
-            // bob gets 63.7442741703 * 0.99 = 63.1068314286
+            // base: 0.01
+            // B2QFee: CH actually shorts 0.01 / 0.99 = 0.0101010101 and get 1.518499515798962 quote
+            // bob gets 1.518499515798962 * 0.99 = 1.503314520640972389
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: true,
                 isExactInput: true,
                 oppositeAmountBound: 0,
-                amount: parseEther("1"),
+                amount: parseEther("0.01"),
                 sqrtPriceLimitX96: 0,
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
-            // current price = 26.3852759058
+            // current price = 149.7299207456
 
             let [netQuoteBalanceAlice, pendingFeeAlice] = await accountBalance.getNetQuoteBalanceAndPendingFee(
                 bob.address,
             )
-            expect(netQuoteBalanceAlice.add(pendingFeeAlice)).to.eq(parseEther("63.106831428587933867"))
+            expect(netQuoteBalanceAlice.add(pendingFeeAlice)).to.eq(parseEther("1.503314520640972389"))
             const [netQuoteBalanceBob, pendingFeeBob] = await accountBalance.getNetQuoteBalanceAndPendingFee(
                 bob.address,
             )
-            expect(netQuoteBalanceBob.add(pendingFeeBob)).to.be.eq(parseEther("63.106831428587933867"))
+            expect(netQuoteBalanceBob.add(pendingFeeBob)).to.be.eq(parseEther("1.503314520640972389"))
 
-            // taker pays 63.7442741703 / 0.99 = 64.3881557276 quote to pay back 1 base
+            // taker pays 1.518499515798962 / 0.99 = 1.5338378947464264 quote to pay back 0.01 base
             await clearingHouse.connect(bob).closePosition({
                 baseToken: baseToken.address,
                 sqrtPriceLimitX96: 0,
@@ -167,14 +167,14 @@ describe("ClearingHouse getNetQuoteBalanceAndPendingFee", () => {
             // taker sells all quote, making netQuoteBalance == 0
             expect((await accountBalance.getNetQuoteBalanceAndPendingFee(bob.address)).netQuoteBalance).to.eq(0)
 
-            // when taker swaps, maker gets 63.106831428587933867 / 0.99 * 0.01 = 0.6374427417
-            // when taker closes position, maker gets 64.388155727566507365 * 0.01 = 0.6438815573
-            // maker should get 0.6374427417 + 0.6438815573 = 1.281324299 quote as fee
+            // when taker swaps, maker gets 1.503314520640972389 / 0.99 * 0.01 = 0.015184995157989621
+            // when taker closes position, maker gets 1.5338378947464264 * 0.01 = 0.015338378947464264
+            // maker should get 0.015184995157989621 + 0.015338378947464264 = 0.030523374105453885 quote as fee
             ;[netQuoteBalanceAlice, pendingFeeAlice] = await accountBalance.getNetQuoteBalanceAndPendingFee(
                 alice.address,
             )
             expect(netQuoteBalanceAlice).to.be.closeTo("0", 1)
-            expect(pendingFeeAlice).to.eq(parseEther("1.281324298978573496"))
+            expect(pendingFeeAlice).to.eq(parseEther("0.030523374105453883"))
         })
 
         it("two makers; a taker swaps and then one maker closes position", async () => {
@@ -202,18 +202,18 @@ describe("ClearingHouse getNetQuoteBalanceAndPendingFee", () => {
                 deadline: ethers.constants.MaxUint256,
             })
 
-            // taker swaps 1 base to 133.884011906796397781 quote
+            // taker swaps 0.01 base to 1.5241759209384165 quote
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: true,
                 isExactInput: true,
                 oppositeAmountBound: 0,
-                amount: parseEther("1"),
+                amount: parseEther("0.01"),
                 sqrtPriceLimitX96: 0,
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
-            // current price = 70.3806594937
+            // current price = 153.91433937753962
 
             // expect taker's netQuoteBalance == makers' netQuoteBalance
             let [aliceNetQuoteBalance, alicePendingFee] = await accountBalance.getNetQuoteBalanceAndPendingFee(
@@ -256,7 +256,7 @@ describe("ClearingHouse getNetQuoteBalanceAndPendingFee", () => {
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
-            // current price = 26.3852759058
+            // current price = 149.7299207455638
             ;[aliceNetQuoteBalance, alicePendingFee] = await accountBalance.getNetQuoteBalanceAndPendingFee(
                 alice.address,
             )

--- a/test/clearingHouse/ClearingHouse.getPositionSize.taker.maker.test.ts
+++ b/test/clearingHouse/ClearingHouse.getPositionSize.taker.maker.test.ts
@@ -80,6 +80,10 @@ describe("ClearingHouse getPositionSize for taker + maker in xyk pool", () => {
             // alice: +20b -250q
             // pool: 100/1000 => 80/1250
             await mintAndDeposit(fixture, alice, 1000)
+
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("15", 6), 0, 0, 0]
+            })
             await q2bExactInput(fixture, alice, 250, baseToken.address)
             takerPositionBefore = await getTakerPositionSize(alice, baseToken)
             takerOpenNotionalBefore = await getTakerOpenNotional(alice, baseToken)
@@ -94,6 +98,10 @@ describe("ClearingHouse getPositionSize for taker + maker in xyk pool", () => {
             // bob: -40b +500q
             // pool: 160/2500 => 200/2000
             await mintAndDeposit(fixture, bob, 1000)
+
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("10", 6), 0, 0, 0]
+            })
             await b2qExactInput(fixture, bob, 40, baseToken.address)
         })
 
@@ -170,10 +178,17 @@ describe("ClearingHouse getPositionSize for taker + maker in xyk pool", () => {
             // bob: +20b -250q
             // pool: 100/1000 => 80/1250
             await mintAndDeposit(fixture, bob, 1000)
+
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("15", 6), 0, 0, 0]
+            })
             await q2bExactInput(fixture, bob, 250, baseToken.address)
 
             // alice: +17.5b -350q
             // alice: 80/1250 => 62.5/1600
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("30", 6), 0, 0, 0]
+            })
             await q2bExactInput(fixture, alice, 350, baseToken.address)
             takerPositionBefore = await getTakerPositionSize(alice, baseToken)
             takerOpenNotionalBefore = await getTakerOpenNotional(alice, baseToken)
@@ -253,6 +268,9 @@ describe("ClearingHouse getPositionSize for taker + maker in xyk pool", () => {
 
     function testClosePosition() {
         it("won't impact maker's position when closing position", async () => {
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("8", 6), 0, 0, 0]
+            })
             await closePosition(fixture, alice)
             expect(await getTakerPositionSize(alice, baseToken)).eq(0)
             expect(await getTakerPositionSize(alice, baseToken)).eq(0)

--- a/test/clearingHouse/ClearingHouse.insuranceFee.test.ts
+++ b/test/clearingHouse/ClearingHouse.insuranceFee.test.ts
@@ -87,6 +87,9 @@ describe("ClearingHouse insurance fee in v3 pool", () => {
     // https://docs.google.com/spreadsheets/d/1H8Sn0YHwbnEjhhA03QOVfOFPPFZUX5Uasg14UY9Gszc/edit#gid=523274954
     describe("swap within the same range", () => {
         beforeEach(async () => {
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("151", 6), 0, 0, 0]
+            })
             await clearingHouse.connect(taker1).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: false,
@@ -193,6 +196,9 @@ describe("ClearingHouse insurance fee in v3 pool", () => {
     })
 
     it("take swaps three times crossing multiple ticks; one after insuranceFundFeeRatio is decreased", async () => {
+        mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+            return [0, parseUnits("151", 6), 0, 0, 0]
+        })
         await clearingHouse.connect(taker1).openPosition({
             baseToken: baseToken.address,
             isBaseToQuote: false,

--- a/test/clearingHouse/ClearingHouse.insuranceFee.xyk.test.ts
+++ b/test/clearingHouse/ClearingHouse.insuranceFee.xyk.test.ts
@@ -97,27 +97,27 @@ describe("ClearingHouse insurance fee in xyk pool", () => {
     })
 
     // https://docs.google.com/spreadsheets/d/1cAldl4tb4HcnyEkxnSEnjXWYrWjt4bw2L2kstasN3VA/edit?usp=sharing
-    describe("quote to base: 250q => 19.83B, maker get fee", () => {
-        it("exact input 250Q", async () => {
+    describe("quote to base: 25Q => 2.415223225176872407B, maker get fee", () => {
+        it("exact input 25Q", async () => {
             await clearingHouse.connect(taker1).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: false,
                 isExactInput: true,
                 oppositeAmountBound: 0,
-                amount: parseEther("250"),
+                amount: parseEther("25"),
                 sqrtPriceLimitX96: 0,
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
         })
 
-        it("exact output 19.83B", async () => {
+        it("exact output 2.415223225176872407B", async () => {
             await clearingHouse.connect(taker1).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: false,
                 isExactInput: false,
                 oppositeAmountBound: ethers.constants.MaxUint256,
-                amount: parseEther("19.839679358717434869"),
+                amount: parseEther("2.415223225176872407"),
                 sqrtPriceLimitX96: 0,
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
@@ -135,8 +135,8 @@ describe("ClearingHouse insurance fee in xyk pool", () => {
                 deadline: ethers.constants.MaxUint256,
             })
             // maker fee = swapped quote * ClearingHouseFeeRatio * (100% - InsuranceFundFeeRatio) * (maker's liquidity / total liquidity within the range)
-            // 250 * 1% * 60% * 90% = 1.35
-            expect(resp1.fee).eq(parseEther("1.35"))
+            // 25 * 1% * 60% * 90% = 0.135
+            expect(resp1.fee).eq(parseEther("0.135"))
 
             const resp2 = await clearingHouse.connect(maker2).callStatic.removeLiquidity({
                 baseToken: baseToken.address,
@@ -147,36 +147,36 @@ describe("ClearingHouse insurance fee in xyk pool", () => {
                 minQuote: 0,
                 deadline: ethers.constants.MaxUint256,
             })
-            // 250 * 1% * 60% * 10% ~= 0.15
-            expect(resp2.fee).eq(parseEther("0.149999999999999999"))
+            // 25 * 1% * 60% * 10% ~= 0.015
+            expect(resp2.fee).eq(parseEther("0.014999999999999999"))
 
             const [owedRealizedPnl] = await accountBalance.getPnlAndPendingFee(insuranceFund.address)
-            // 250 * 1% * 40% ~= 1
-            expect(owedRealizedPnl).eq(parseEther("1"))
+            // 25 * 1% * 40% ~= 0.1
+            expect(owedRealizedPnl).eq(parseEther("0.1"))
         })
     })
 
-    describe("base to quote: 25B => 198Q, maker get fee", () => {
-        it("exact input 25B", async () => {
+    describe("base to quote: 2.5B => 24.146341463414634146Q, maker get fee", () => {
+        it("exact input 2.5B", async () => {
             await clearingHouse.connect(taker1).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: true,
                 isExactInput: true,
                 oppositeAmountBound: 0,
-                amount: parseEther("25"),
+                amount: parseEther("2.5"),
                 sqrtPriceLimitX96: 0,
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
         })
 
-        it("exact output 198Q", async () => {
+        it("exact output 24.146341463414634146Q", async () => {
             await clearingHouse.connect(taker1).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: true,
                 isExactInput: false,
                 oppositeAmountBound: ethers.constants.MaxUint256,
-                amount: parseEther("198"),
+                amount: parseEther("24.146341463414634146"),
                 sqrtPriceLimitX96: 0,
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
@@ -193,8 +193,8 @@ describe("ClearingHouse insurance fee in xyk pool", () => {
                 minQuote: 0,
                 deadline: ethers.constants.MaxUint256,
             })
-            // 200 * 1% * 60% * 90% = 1.08
-            expect(resp1.fee).eq(parseEther("1.08"))
+            // 24.3902439024 * 1% * 60% * 90% = 0.1317073171
+            expect(resp1.fee).eq(parseEther("0.131707317073170731"))
 
             const resp2 = await clearingHouse.connect(maker2).callStatic.removeLiquidity({
                 baseToken: baseToken.address,
@@ -205,12 +205,12 @@ describe("ClearingHouse insurance fee in xyk pool", () => {
                 minQuote: 0,
                 deadline: ethers.constants.MaxUint256,
             })
-            // 200 * 1% * 60% * 10% ~= 0.12
-            expect(resp2.fee).eq(parseEther("0.119999999999999999"))
+            // 24.3902439024 * 1% * 60% * 10% ~= 0.01463414634
+            expect(resp2.fee).eq(parseEther("0.014634146341463414"))
 
             const [owedRealizedPnl] = await accountBalance.getPnlAndPendingFee(insuranceFund.address)
-            // 200 * 1% * 40% ~= 0.8
-            expect(owedRealizedPnl).eq(parseEther("0.8"))
+            // 24.3902439024 * 1% * 40% ~= 0.09756097561
+            expect(owedRealizedPnl).eq(parseEther("0.097560975609756098"))
         })
     })
 })

--- a/test/clearingHouse/ClearingHouse.liquidate.maker.ts
+++ b/test/clearingHouse/ClearingHouse.liquidate.maker.ts
@@ -123,6 +123,8 @@ describe("ClearingHouse liquidate maker", () => {
         // bob long
         await collateral.mint(bob.address, parseUnits("10000000", collateralDecimals))
         await deposit(bob, vault, 10000000, collateral)
+
+        setPoolIndexPrice(40, Pool.Pool1)
         await clearingHouse.connect(bob).openPosition({
             baseToken: baseToken.address,
             isBaseToQuote: false, // quote to base
@@ -146,6 +148,8 @@ describe("ClearingHouse liquidate maker", () => {
         // bob long
         await collateral.mint(bob.address, parseUnits("10000000", collateralDecimals))
         await deposit(bob, vault, 10000000, collateral)
+
+        setPoolIndexPrice(40, Pool.Pool1)
         await clearingHouse.connect(bob).openPosition({
             baseToken: baseToken.address,
             isBaseToQuote: false, // quote to base
@@ -229,6 +233,8 @@ describe("ClearingHouse liquidate maker", () => {
             // bob long
             await collateral.mint(bob.address, parseUnits("10000000", collateralDecimals))
             await deposit(bob, vault, 10000000, collateral)
+
+            setPoolIndexPrice(40, Pool.Pool1)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: false, // quote to base
@@ -338,6 +344,8 @@ describe("ClearingHouse liquidate maker", () => {
             // bob long
             await collateral.mint(bob.address, parseUnits("10000000", collateralDecimals))
             await deposit(bob, vault, 10000000, collateral)
+
+            setPoolIndexPrice(40, Pool.Pool1)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: false, // quote to base
@@ -458,6 +466,8 @@ describe("ClearingHouse liquidate maker", () => {
                 // bob long in pool1
                 await collateral.mint(bob.address, parseUnits("10000000", collateralDecimals))
                 await deposit(bob, vault, 10000000, collateral)
+
+                setPoolIndexPrice(40, Pool.Pool1)
                 await clearingHouse.connect(bob).openPosition({
                     baseToken: baseToken.address,
                     isBaseToQuote: false, // quote to base
@@ -470,6 +480,7 @@ describe("ClearingHouse liquidate maker", () => {
                 })
 
                 // bob long in pool2
+                setPoolIndexPrice(40, Pool.Pool2)
                 await clearingHouse.connect(bob).openPosition({
                     baseToken: baseToken2.address,
                     isBaseToQuote: false, // quote to base
@@ -555,6 +566,7 @@ describe("ClearingHouse liquidate maker", () => {
                     })
 
                     // bob long in pool1
+                    setPoolIndexPrice(40, Pool.Pool1)
                     await clearingHouse.connect(bob).openPosition({
                         baseToken: baseToken.address,
                         isBaseToQuote: false, // quote to base
@@ -647,6 +659,7 @@ describe("ClearingHouse liquidate maker", () => {
 
                 it("one order in each market; liquidation in pool2 doesn't help margin ratio, thus also liquidating the position in pool1", async () => {
                     // bob long in pool1
+                    setPoolIndexPrice(40, Pool.Pool1)
                     await clearingHouse.connect(bob).openPosition({
                         baseToken: baseToken.address,
                         isBaseToQuote: false, // quote to base
@@ -659,6 +672,7 @@ describe("ClearingHouse liquidate maker", () => {
                     })
 
                     // bob long in pool2
+                    setPoolIndexPrice(40, Pool.Pool2)
                     await clearingHouse.connect(bob).openPosition({
                         baseToken: baseToken2.address,
                         isBaseToQuote: false, // quote to base
@@ -738,6 +752,8 @@ describe("ClearingHouse liquidate maker", () => {
             // bob long on pool1, and alice and carol get shorts
             await collateral.mint(bob.address, parseUnits("10000000", collateralDecimals))
             await deposit(bob, vault, 10000000, collateral)
+
+            setPoolIndexPrice(40, Pool.Pool1)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: false, // quote to base
@@ -750,6 +766,7 @@ describe("ClearingHouse liquidate maker", () => {
             })
 
             // bob long on pool2, and alice and carol get shorts
+            setPoolIndexPrice(40, Pool.Pool2)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken2.address,
                 isBaseToQuote: false, // quote to base
@@ -788,6 +805,8 @@ describe("ClearingHouse liquidate maker", () => {
             // bob long on pool1
             await collateral.mint(bob.address, parseUnits("10000000", collateralDecimals))
             await deposit(bob, vault, 10000000, collateral)
+
+            setPoolIndexPrice(40, Pool.Pool1)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: false, // quote to base
@@ -800,6 +819,7 @@ describe("ClearingHouse liquidate maker", () => {
             })
 
             // bob long on pool2
+            setPoolIndexPrice(40, Pool.Pool2)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken2.address,
                 isBaseToQuote: false, // quote to base
@@ -810,8 +830,10 @@ describe("ClearingHouse liquidate maker", () => {
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
+
             // only pool1 index price goes up
             setPoolIndexPrice(105, Pool.Pool1)
+            setPoolIndexPrice(10, Pool.Pool2)
 
             // cancel maker's order on all markets
             await clearingHouse.connect(davis).cancelAllExcessOrders(alice.address, baseToken.address)
@@ -838,6 +860,8 @@ describe("ClearingHouse liquidate maker", () => {
             // bob long on pool1
             await collateral.mint(bob.address, parseUnits("10000000", collateralDecimals))
             await deposit(bob, vault, 10000000, collateral)
+
+            setPoolIndexPrice(40, Pool.Pool1)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: false, // quote to base
@@ -850,6 +874,7 @@ describe("ClearingHouse liquidate maker", () => {
             })
 
             // bob long on pool2
+            setPoolIndexPrice(40, Pool.Pool2)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken2.address,
                 isBaseToQuote: false, // quote to base

--- a/test/clearingHouse/ClearingHouse.openPosition.isReducePosition.ts
+++ b/test/clearingHouse/ClearingHouse.openPosition.isReducePosition.ts
@@ -60,13 +60,13 @@ describe("ClearingHouse isIncreasePosition when trader is both of maker and take
             await addOrder(fixture, alice, 100, 10000, lowerTick, upperTick)
 
             // bob swap let alice has maker position
-            // alice maker positionSize : -5
-            await q2bExactOutput(fixture, bob, 5)
+            // alice maker positionSize : -1
+            await q2bExactOutput(fixture, bob, 1)
 
             // alice swap
-            // alice maker positionSize : -6
+            // alice maker positionSize : -2
             // alice taker positionSize : 1
-            // taker open notional will be: -11311321501691042565
+            // taker open notional will be: -10307153164296021439
             await q2bExactOutput(fixture, alice, 1)
 
             expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.deep.eq(
@@ -74,25 +74,25 @@ describe("ClearingHouse isIncreasePosition when trader is both of maker and take
             )
 
             // bob swap to let alice taker position pnl > 0
-            // alice maker positionSize : -7
+            // alice maker positionSize : -3
             // alice taker positionSize : 1
             await q2bExactOutput(fixture, bob, 1)
 
             // alice reduce position
-            // alice maker positionSize : -6.5
+            // alice maker positionSize : -2.5
             // alice taker positionSize : 0.5
             const tx = await b2qExactInput(fixture, alice, 0.5)
             await expect(tx).to.emit(clearingHouse, "PositionChanged").withArgs(
                 alice.address,
                 baseToken.address,
                 parseEther("-0.5"),
-                "5750100626760968316",
-                "57501006267609684",
-                "-5655660750845521283",
-                "36938869647837350", // 5692599620493358632(deltaQuote) - 11311321501691042565(old taker open notional) * 0.5 = 3.693886965E16
-                "267958768315559284688164142991",
+                "5286809410520750726",
+                "52868094105207508",
+                "-5205632911260616889",
+                "28308405154926330", // 5.181884987302938(deltaQuote) - 10.307153164296021439(old taker open notional) * 0.5 = 0.028308405154926330
+                "256965588076972237113143126655",
             )
-            await expect(tx).to.emit(accountBalance, "PnlRealized").withArgs(alice.address, "36938869647837350")
+            await expect(tx).to.emit(accountBalance, "PnlRealized").withArgs(alice.address, "28308405154926330")
 
             expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.deep.eq(
                 parseEther("0.5"),
@@ -100,7 +100,7 @@ describe("ClearingHouse isIncreasePosition when trader is both of maker and take
 
             // total position size = taker position size + maker position size
             expect(await accountBalance.getTotalPositionSize(alice.address, baseToken.address)).to.be.closeTo(
-                parseEther("-6"),
+                parseEther("-2"),
                 1,
             )
         })
@@ -111,13 +111,13 @@ describe("ClearingHouse isIncreasePosition when trader is both of maker and take
 
             // bob swap let alice has maker position
 
-            // alice maker positionSize : -5
-            await q2bExactOutput(fixture, bob, 5)
+            // alice maker positionSize : -1
+            await q2bExactOutput(fixture, bob, 1)
 
             // alice swap
-            // alice maker positionSize : -4
+            // alice maker positionSize : 0
             // alice taker positionSize : -1
-            // taker open notional will be: 10855263157894736841
+            // taker open notional will be: 10.101010101
             await b2qExactInput(fixture, alice, 1)
 
             expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.deep.eq(
@@ -125,20 +125,20 @@ describe("ClearingHouse isIncreasePosition when trader is both of maker and take
             )
 
             // alice reduce position
-            // alice maker positionSize : -4.5
+            // alice maker positionSize : -0.5
             // alice taker positionSize : -0.5
             const tx = await q2bExactOutput(fixture, alice, 0.5)
             await expect(tx).to.emit(clearingHouse, "PositionChanged").withArgs(
                 alice.address,
                 baseToken.address,
                 parseEther("0.5"),
-                "-5453752181500872601",
-                "55088405873746188",
-                "5427631578947368421",
-                "-81209008427250369", // -5508840587374618789(deltaQuote) + 10855263157894736841(old taker open notional) * 0.5 = -8.12090084e16
-                "262347066361306734224496029540",
+                "-5025125628140703518",
+                "50758844728693975",
+                "5000000000000000000",
+                "-75884472869397494", // -5.3517471060799995(deltaQuote) + 10.8552631579(old taker open notional) * 0.5 = -0.07588447287
+                "251800450628188875564018462374",
             )
-            await expect(tx).to.emit(accountBalance, "PnlRealized").withArgs(alice.address, "-81209008427250369")
+            await expect(tx).to.emit(accountBalance, "PnlRealized").withArgs(alice.address, "-75884472869397494")
 
             expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.deep.eq(
                 parseEther("-0.5"),
@@ -146,7 +146,7 @@ describe("ClearingHouse isIncreasePosition when trader is both of maker and take
 
             // total position size = taker position size + maker position size
             expect(await accountBalance.getTotalPositionSize(alice.address, baseToken.address)).to.be.closeTo(
-                parseEther("-5"),
+                parseEther("-1"),
                 1,
             )
         })
@@ -156,29 +156,34 @@ describe("ClearingHouse isIncreasePosition when trader is both of maker and take
             await addOrder(fixture, alice, 20, 1000, lowerTick, upperTick)
             // max tick crossed: 1774544, current tick: 23027
 
+            // mock index price higher to let taker open long position (will test reduce taker long position)
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("40", 6), 0, 0, 0]
+            })
+
             // bob swap let alice has maker position
-            // alice maker positionSize : -10
+            // alice maker positionSize : -9
             // alice taker positionSize: 0
-            await q2bExactOutput(fixture, bob, 10)
-            //  max tick crossed: 1774544, current tick: 36890
+            await q2bExactOutput(fixture, bob, 9)
+            //  max tick crossed: 1774544, current tick: 34984
 
             // alice swap
-            // alice maker positionSize : -15
-            // alice taker positionSize : 5
-            await q2bExactOutput(fixture, alice, 5)
-            // max tick crossed: 1774544, current tick: 50754
+            // alice maker positionSize : -10
+            // alice taker positionSize : 1
+            await q2bExactOutput(fixture, alice, 1)
+            // max tick crossed: 1774544, current tick: 36890
 
             expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.deep.eq(
-                parseEther("5"),
+                parseEther("1"),
             )
 
             // set MaxTickCrossedWithinBlock so that trigger over price limit
-            await exchange.setMaxTickCrossedWithinBlock(baseToken.address, 1000)
-            // max tick crossed: 1000, current tick: 50754
+            await exchange.setMaxTickCrossedWithinBlock(baseToken.address, 250)
+            // max tick crossed: 250, current tick: 36890
 
             // expect revert due to over price limit
             // alice reduce taker position
-            await expect(b2qExactInput(fixture, alice, 5)).to.be.revertedWith("EX_OPLAS")
+            await expect(b2qExactInput(fixture, alice, 0.5)).to.be.revertedWith("EX_OPLAS")
         })
     })
 })

--- a/test/clearingHouse/ClearingHouse.openPosition.maker.test.ts
+++ b/test/clearingHouse/ClearingHouse.openPosition.maker.test.ts
@@ -81,14 +81,14 @@ describe("ClearingHouse maker close position", () => {
     // https://docs.google.com/spreadsheets/d/1kjs6thR9hXP2CCgn9zDcQESV5sWWumWIsKjBKJJC7Oc/edit#gid=574020995
     it("bob long, maker remove and close", async () => {
         // bob long
-        await collateral.mint(bob.address, parseUnits("250", collateralDecimals))
-        await deposit(bob, vault, 250, collateral)
+        await collateral.mint(bob.address, parseUnits("25", collateralDecimals))
+        await deposit(bob, vault, 25, collateral)
         await clearingHouse.connect(bob).openPosition({
             baseToken: baseToken.address,
             isBaseToQuote: false, // quote to base
             isExactInput: true,
             oppositeAmountBound: 0, // exact input (quote)
-            amount: parseEther("250"),
+            amount: parseEther("25"),
             sqrtPriceLimitX96: 0,
             deadline: ethers.constants.MaxUint256,
             referralCode: ethers.constants.HashZero,
@@ -108,7 +108,7 @@ describe("ClearingHouse maker close position", () => {
         })
 
         // maker close position
-        // positionSize: -1983967935871743488
+        // positionSize: -0.2415223225
         const posSize = await accountBalance.getTotalPositionSize(alice.address, baseToken.address)
         // maker should settle maker position to taker position
         expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.eq(posSize)
@@ -126,20 +126,20 @@ describe("ClearingHouse maker close position", () => {
 
         // available + earned fee - debt = (124.75 - 31.75 - 0.32) + (2.5 * 10%) - 100 = -7.07
         const [aliceOwedPnl] = await accountBalance.getPnlAndPendingFee(alice.address)
-        expect(aliceOwedPnl).to.closeTo(parseEther("-7.069408740359897192"), 1)
+        expect(aliceOwedPnl).to.closeTo(parseEther("-0.068939583855602924"), 1)
         expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.eq("0")
     })
 
     it("bob long, maker remove, reduce half then close", async () => {
         // bob long
-        await collateral.mint(bob.address, parseUnits("250", collateralDecimals))
-        await deposit(bob, vault, 250, collateral)
+        await collateral.mint(bob.address, parseUnits("25", collateralDecimals))
+        await deposit(bob, vault, 25, collateral)
         await clearingHouse.connect(bob).openPosition({
             baseToken: baseToken.address,
             isBaseToQuote: false, // quote to base
             isExactInput: true,
             oppositeAmountBound: 0, // exact input (quote)
-            amount: parseEther("250"),
+            amount: parseEther("25"),
             sqrtPriceLimitX96: 0,
             deadline: ethers.constants.MaxUint256,
             referralCode: ethers.constants.HashZero,
@@ -174,7 +174,7 @@ describe("ClearingHouse maker close position", () => {
 
             // include pnl, collectedFee and fundingPayment
             const [aliceOwedPnl] = await accountBalance.getPnlAndPendingFee(alice.address)
-            expect(aliceOwedPnl).to.closeTo(parseEther("-3.186153358681875804"), 1)
+            expect(aliceOwedPnl).to.closeTo(parseEther("-0.020201214169483049"), 1)
             expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.eq(posSize.div(2))
         }
 
@@ -191,7 +191,7 @@ describe("ClearingHouse maker close position", () => {
             referralCode: ethers.constants.HashZero,
         })
         const [aliceOwedPnl] = await accountBalance.getPnlAndPendingFee(alice.address)
-        expect(aliceOwedPnl).closeTo(parseEther("-7.069408740359897191"), 3)
+        expect(aliceOwedPnl).closeTo(parseEther("-0.068939583855602925"), 3)
         expect(await accountBalance.getTakerPositionSize(alice.address, baseToken.address)).to.be.eq("0")
     })
 
@@ -204,7 +204,7 @@ describe("ClearingHouse maker close position", () => {
             isBaseToQuote: true,
             isExactInput: true,
             oppositeAmountBound: 0,
-            amount: parseEther("25"),
+            amount: parseEther("2.5"),
             sqrtPriceLimitX96: 0,
             deadline: ethers.constants.MaxUint256,
             referralCode: ethers.constants.HashZero,
@@ -238,7 +238,7 @@ describe("ClearingHouse maker close position", () => {
 
         // available + earned fee - debt = (80 - -15.65 - 0.16) + (2 * 10%) - 100 = -4.3043478260869
         const [aliceOwedPnl] = await accountBalance.getPnlAndPendingFee(alice.address)
-        expect(aliceOwedPnl).deep.eq(parseEther("-4.304347826086956531"))
+        expect(aliceOwedPnl).deep.eq(parseEther("-0.065260382333553077"))
     })
 
     describe("maker for more than 1 market", () => {
@@ -283,14 +283,14 @@ describe("ClearingHouse maker close position", () => {
 
         it("bob long, maker remove and close", async () => {
             // bob long
-            await collateral.mint(bob.address, parseUnits("250", collateralDecimals))
-            await deposit(bob, vault, 250, collateral)
+            await collateral.mint(bob.address, parseUnits("25", collateralDecimals))
+            await deposit(bob, vault, 25, collateral)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: false, // quote to base
                 isExactInput: true,
                 oppositeAmountBound: 0, // exact input (quote)
-                amount: parseEther("250"),
+                amount: parseEther("25"),
                 sqrtPriceLimitX96: 0,
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
@@ -324,19 +324,19 @@ describe("ClearingHouse maker close position", () => {
 
             // should be same as the situation when adding liquidity in 1 pool
             const [aliceOwedPnl] = await accountBalance.getPnlAndPendingFee(alice.address)
-            expect(aliceOwedPnl).to.closeTo(parseEther("-7.069408740359897192"), 1)
+            expect(aliceOwedPnl).to.closeTo(parseEther("-0.068939583855602924"), 1)
         })
 
         it("bob short, maker close", async () => {
             // bob long
-            await collateral.mint(bob.address, parseUnits("250", collateralDecimals))
-            await deposit(bob, vault, 250, collateral)
+            await collateral.mint(bob.address, parseUnits("25", collateralDecimals))
+            await deposit(bob, vault, 25, collateral)
             await clearingHouse.connect(bob).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: true,
                 isExactInput: true,
                 oppositeAmountBound: 0,
-                amount: parseEther("25"),
+                amount: parseEther("2.5"),
                 sqrtPriceLimitX96: 0,
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
@@ -370,7 +370,7 @@ describe("ClearingHouse maker close position", () => {
 
             // should be same as the situation when adding liquidity in 1 pool
             const [aliceOwedPnl] = await accountBalance.getPnlAndPendingFee(alice.address)
-            expect(aliceOwedPnl).deep.eq(parseEther("-4.304347826086956531"))
+            expect(aliceOwedPnl).deep.eq(parseEther("-0.065260382333553077"))
         })
     })
 })

--- a/test/clearingHouse/ClearingHouse.openPosition.oneWeiFee.test.ts
+++ b/test/clearingHouse/ClearingHouse.openPosition.oneWeiFee.test.ts
@@ -100,12 +100,12 @@ describe("ClearingHouse openPosition oneWeiFee", () => {
                     isBaseToQuote: true,
                     isExactInput: false,
                     oppositeAmountBound: 0,
-                    amount: parseEther("1000"),
+                    amount: parseEther("10"),
                     sqrtPriceLimitX96: 0,
                     deadline: ethers.constants.MaxUint256,
                     referralCode: ethers.constants.HashZero,
                 })
-                expect(response.quote).to.be.eq(parseEther("1000"))
+                expect(response.quote).to.be.eq(parseEther("10"))
             })
 
             it("long exact input", async () => {
@@ -114,26 +114,26 @@ describe("ClearingHouse openPosition oneWeiFee", () => {
                     isBaseToQuote: false,
                     isExactInput: true,
                     oppositeAmountBound: 0,
-                    amount: "1280383806188353801279",
+                    amount: "12803838061883538012",
                     sqrtPriceLimitX96: 0,
                     deadline: ethers.constants.MaxUint256,
                     referralCode: ethers.constants.HashZero,
                 })
-                expect(response.quote).to.be.eq("1280383806188353801279")
+                expect(response.quote).to.be.eq("12803838061883538012")
             })
 
-            it("long exact input with 1000", async () => {
+            it("long exact input with 10", async () => {
                 const response = await clearingHouse.connect(taker).callStatic.openPosition({
                     baseToken: baseToken.address,
                     isBaseToQuote: false,
                     isExactInput: true,
                     oppositeAmountBound: 0,
-                    amount: parseEther("1000"),
+                    amount: parseEther("10"),
                     sqrtPriceLimitX96: 0,
                     deadline: ethers.constants.MaxUint256,
                     referralCode: ethers.constants.HashZero,
                 })
-                expect(response.quote).to.be.eq(parseEther("1000"))
+                expect(response.quote).to.be.eq(parseEther("10"))
             })
         })
 

--- a/test/clearingHouse/ClearingHouse.openPosition.slippage.xyk.test.ts
+++ b/test/clearingHouse/ClearingHouse.openPosition.slippage.xyk.test.ts
@@ -71,7 +71,7 @@ describe("ClearingHouse slippage in xyk pool", () => {
                     baseToken: baseToken.address,
                     isBaseToQuote: true,
                     isExactInput: true,
-                    amount: parseEther("25"),
+                    amount: parseEther("2.5"),
                     oppositeAmountBound: parseEther("200"),
                     sqrtPriceLimitX96: 0,
                     deadline: ethers.constants.MaxUint256,
@@ -81,14 +81,14 @@ describe("ClearingHouse slippage in xyk pool", () => {
         })
 
         it("B2Q + exact output, want less input base as possible, so we set a upper bound of input base", async () => {
-            // taker swap exact 250 USD for expected 20 ETH but got less
+            // taker swap exact 25 USD for expected 2.5 ETH but got less
             await expect(
                 clearingHouse.connect(taker).openPosition({
                     baseToken: baseToken.address,
                     isBaseToQuote: true,
                     isExactInput: false,
-                    amount: parseEther("250"),
-                    oppositeAmountBound: parseEther("25"),
+                    amount: parseEther("25"),
+                    oppositeAmountBound: parseEther("2.5"),
                     sqrtPriceLimitX96: 0,
                     deadline: ethers.constants.MaxUint256,
                     referralCode: ethers.constants.HashZero,
@@ -97,13 +97,13 @@ describe("ClearingHouse slippage in xyk pool", () => {
         })
 
         it("Q2B + exact input, want more output base as possible, so we set a lower bound of output base", async () => {
-            // taker swap exact 250 USD for expected 20 ETH but got less
+            // taker swap exact 25 USD for expected 20 ETH but got less
             await expect(
                 clearingHouse.connect(taker).openPosition({
                     baseToken: baseToken.address,
                     isBaseToQuote: false,
                     isExactInput: true,
-                    amount: parseEther("250"),
+                    amount: parseEther("25"),
                     oppositeAmountBound: parseEther("20"),
                     sqrtPriceLimitX96: 0,
                     deadline: ethers.constants.MaxUint256,
@@ -113,14 +113,14 @@ describe("ClearingHouse slippage in xyk pool", () => {
         })
 
         it("Q2B + exact output want less input quote as possible, so we set a upper bound of input quote", async () => {
-            // taker swap exact 250 USD for expected 20 ETH but got less
+            // taker swap exact 2.5 USD for expected 2 ETH but got less
             await expect(
                 clearingHouse.connect(taker).openPosition({
                     baseToken: baseToken.address,
                     isBaseToQuote: false,
                     isExactInput: false,
-                    amount: parseEther("20"),
-                    oppositeAmountBound: parseEther("250"),
+                    amount: parseEther("2"),
+                    oppositeAmountBound: parseEther("2.5"),
                     sqrtPriceLimitX96: 0,
                     deadline: ethers.constants.MaxUint256,
                     referralCode: ethers.constants.HashZero,
@@ -131,10 +131,35 @@ describe("ClearingHouse slippage in xyk pool", () => {
 
     describe("closePosition", () => {
         it("open short then close", async () => {
-            // taker shorts 25 ETH with roughly 200 USD
+            // taker shorts 2.5 ETH with roughly 24 USD
             await clearingHouse.connect(taker).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: true,
+                isExactInput: true,
+                amount: parseEther("2.5"),
+                oppositeAmountBound: 0,
+                sqrtPriceLimitX96: 0,
+                deadline: ethers.constants.MaxUint256,
+                referralCode: ethers.constants.HashZero,
+            })
+
+            // taker wants to close 2.5 ETH short for 24 USD but get less bcs of the tx fee
+            await expect(
+                clearingHouse.connect(taker).closePosition({
+                    baseToken: baseToken.address,
+                    sqrtPriceLimitX96: 0,
+                    oppositeAmountBound: parseEther("24"),
+                    deadline: ethers.constants.MaxUint256,
+                    referralCode: ethers.constants.HashZero,
+                }),
+            ).to.be.revertedWith("CH_TMRL")
+        })
+
+        it("open long then close", async () => {
+            // taker longs for roughly 2.4 ETH with 25 USD
+            await clearingHouse.connect(taker).openPosition({
+                baseToken: baseToken.address,
+                isBaseToQuote: false,
                 isExactInput: true,
                 amount: parseEther("25"),
                 oppositeAmountBound: 0,
@@ -143,37 +168,12 @@ describe("ClearingHouse slippage in xyk pool", () => {
                 referralCode: ethers.constants.HashZero,
             })
 
-            // taker wants to close 25 ETH short for 200 USD but get less bcs of the tx fee
+            // taker wants to close 2.4 ETH long for 25 USD but get less bcs of the tx fee
             await expect(
                 clearingHouse.connect(taker).closePosition({
                     baseToken: baseToken.address,
                     sqrtPriceLimitX96: 0,
-                    oppositeAmountBound: parseEther("200"),
-                    deadline: ethers.constants.MaxUint256,
-                    referralCode: ethers.constants.HashZero,
-                }),
-            ).to.be.revertedWith("CH_TMRL")
-        })
-
-        it("open long then close", async () => {
-            // taker longs for roughly 20 ETH with 250 USD
-            await clearingHouse.connect(taker).openPosition({
-                baseToken: baseToken.address,
-                isBaseToQuote: false,
-                isExactInput: true,
-                amount: parseEther("250"),
-                oppositeAmountBound: 0,
-                sqrtPriceLimitX96: 0,
-                deadline: ethers.constants.MaxUint256,
-                referralCode: ethers.constants.HashZero,
-            })
-
-            // taker wants to close 20 ETH long for 250 USD but get less bcs of the tx fee
-            await expect(
-                clearingHouse.connect(taker).closePosition({
-                    baseToken: baseToken.address,
-                    sqrtPriceLimitX96: 0,
-                    oppositeAmountBound: parseEther("250"),
+                    oppositeAmountBound: parseEther("25"),
                     deadline: ethers.constants.MaxUint256,
                     referralCode: ethers.constants.HashZero,
                 }),

--- a/test/clearingHouse/ClearingHouse.openPosition.test.ts
+++ b/test/clearingHouse/ClearingHouse.openPosition.test.ts
@@ -255,7 +255,7 @@ describe("ClearingHouse openPosition", () => {
                         isBaseToQuote: true,
                         isExactInput: false,
                         oppositeAmountBound: 0,
-                        amount: parseEther("100"),
+                        amount: parseEther("0.001"),
                         sqrtPriceLimitX96: 0,
                         deadline: ethers.constants.MaxUint256,
                         referralCode: ethers.constants.HashZero,
@@ -281,7 +281,7 @@ describe("ClearingHouse openPosition", () => {
                         isBaseToQuote: false,
                         isExactInput: true,
                         oppositeAmountBound: 0,
-                        amount: parseEther("100"),
+                        amount: parseEther("0.001"),
                         sqrtPriceLimitX96: 0,
                         deadline: ethers.constants.MaxUint256,
                         referralCode: ethers.constants.HashZero,
@@ -791,6 +791,9 @@ describe("ClearingHouse openPosition", () => {
 
             // carol pays $1000 for ETH long
             // 71.8931973198 - 884.6906588359 ^ 2 / (10886.6706588362 + 990) = 5.9927792385
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("180", 6), 0, 0, 0]
+            })
             await clearingHouse.connect(carol).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: false,
@@ -809,6 +812,9 @@ describe("ClearingHouse openPosition", () => {
             //   amount out would be:
             //     11876.6706588362 - 884.6906588359 ^ 2 / (65.9004180813 + 0.013077866441492721) = 2.3564447634
             // taker gets 2.3564447634 * 0.99 = 2.3328803158
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("151", 6), 0, 0, 0]
+            })
             await clearingHouse.connect(taker).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: true,
@@ -859,6 +865,9 @@ describe("ClearingHouse openPosition", () => {
             // carol pays for $1000 ETH short
             // B2QFee: CH actually gets 1000 / 0.99 = 1010.101010101 quote
             // 884.6906588359 ^ 2 / (10886.6706588362 - 1010.101010101) - 71.8931973198 = 7.3526936796
+            mockedBaseAggregator.smocked.latestRoundData.will.return.with(async () => {
+                return [0, parseUnits("124", 6), 0, 0, 0]
+            })
             await clearingHouse.connect(carol).openPosition({
                 baseToken: baseToken.address,
                 isBaseToQuote: true,
@@ -1247,7 +1256,7 @@ describe("ClearingHouse openPosition", () => {
                     isBaseToQuote: true,
                     isExactInput: true,
                     oppositeAmountBound: 0,
-                    amount: parseEther("10"),
+                    amount: parseEther("1"),
                     sqrtPriceLimitX96: 0,
                     deadline: ethers.constants.MaxUint256,
                     referralCode: ethers.constants.HashZero,

--- a/test/clearingHouse/ClearingHouse.openPosition.xyk.test.ts
+++ b/test/clearingHouse/ClearingHouse.openPosition.xyk.test.ts
@@ -167,10 +167,6 @@ describe("ClearingHouse openPosition in xyk pool", () => {
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
-
-            console.log(
-                `taker open notional: ${await accountBalance.getTotalOpenNotional(taker.address, baseToken.address)}`,
-            )
         })
 
         describe("open another long", () => {

--- a/test/clearingHouse/ClearingHouse.partialClose.test.ts
+++ b/test/clearingHouse/ClearingHouse.partialClose.test.ts
@@ -146,14 +146,14 @@ describe("ClearingHouse partial close in xyk pool", () => {
         })
 
         it("force error, partial closing a position does not apply to opening a reverse position with openPosition", async () => {
-            // carol longs 25 eth
+            // carol longs 2.5 eth
             await expect(
                 clearingHouse.connect(carol).openPosition({
                     baseToken: baseToken.address,
                     isBaseToQuote: false,
                     isExactInput: false,
                     oppositeAmountBound: ethers.constants.MaxUint256,
-                    amount: parseEther("25"),
+                    amount: parseEther("2.5"),
                     sqrtPriceLimitX96: 0,
                     deadline: ethers.constants.MaxUint256,
                     referralCode: ethers.constants.HashZero,

--- a/test/clearingHouse/ClearingHouse.partialClose.test.ts
+++ b/test/clearingHouse/ClearingHouse.partialClose.test.ts
@@ -101,13 +101,13 @@ describe("ClearingHouse partial close in xyk pool", () => {
                 isBaseToQuote: true,
                 isExactInput: true,
                 oppositeAmountBound: 0,
-                amount: parseEther("25"),
+                amount: parseEther("2.5"),
                 sqrtPriceLimitX96: 0,
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
 
-            expect(await accountBalance.getTotalPositionSize(carol.address, baseToken.address)).eq(parseEther("-25"))
+            expect(await accountBalance.getTotalPositionSize(carol.address, baseToken.address)).eq(parseEther("-2.5"))
 
             // move to next 15 secs to renew the over price checking window,to simplify test case
             await forwardBothTimestamps(clearingHouse, 15)
@@ -130,7 +130,7 @@ describe("ClearingHouse partial close in xyk pool", () => {
                 deadline: ethers.constants.MaxUint256,
                 referralCode: ethers.constants.HashZero,
             })
-            expect(await accountBalance.getTotalPositionSize(carol.address, baseToken.address)).eq(parseEther("-24.9"))
+            expect(await accountBalance.getTotalPositionSize(carol.address, baseToken.address)).eq(parseEther("-2.4"))
         })
 
         it("revert when it's over price limit", async () => {

--- a/test/clearingHouse/ClearingHouse.removeLiquidity.with_fee(maker).test.ts
+++ b/test/clearingHouse/ClearingHouse.removeLiquidity.with_fee(maker).test.ts
@@ -1200,11 +1200,11 @@ describe("ClearingHouse removeLiquidity with fee", () => {
             await addOrder(fixture, alice, 10, 2000, lowerTick, upperTick)
 
             // bob trade
-            await q2bExactInput(fixture, bob, 123.456)
+            await q2bExactInput(fixture, bob, 12.3456)
             // carol trade
-            await q2bExactInput(fixture, carol, 654.321)
+            await q2bExactInput(fixture, carol, 6.54321)
             // davis trade
-            await b2qExactInput(fixture, davis, 1.0002)
+            await b2qExactInput(fixture, davis, 0.10002)
 
             // carol close
             await closePosition(fixture, carol)


### PR DESCRIPTION
- [x] ClearingHouse openPosition xyk test
- [x] AccountBalance test
- [x] ClearingHouse 7494
- [x] ClearingHouse accounting xyk
- [x] ClearingHouse badDebt
- [x] ClearingHouse cancelExcessOrders 
- [x] ClearingHouse closePosition
- [x] ClearingHouse customized fee
- [x] ClearingHouse getNetQuoteBalanceAndPendingFee
- [x] ClearingHouse getPositionSize for taker + maker in xyk pool
- [x] ClearingHouse insurance fee in v3 pool
- [x] ClearingHouse insurance fee in xyk pool
- [x] ClearingHouse liquidate maker
- [x] ClearingHouse isIncreasePosition when trader is both of maker and taker
- [x] ClearingHouse maker close position
- [x] ClearingHouse openPosition oneWeiFee
- [x] ClearingHouse slippage in xyk pool
- [x] ClearingHouse openPosition
- [x] ClearingHouse partial close in xyk pool
- [x] ClearingHouse removeLiquidity with fee