### PR TITLE
Feature/add max price spread ratio to markt info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Added a new field, maxPriceSpreadRatio, to the `IMarketRegistry.MarketInfo` struct. The `MarketRegistry.getMarketInfo` function will now return the maxPriceSpreadRatio value for a market.
 
 ## [2.4.5] - 2023-03-28
 - Ensure that the market price should be within a price band (defaulting to the index price +/- 10%, but adaptable to market conditions) before performing any swaps, including opening, reducing, or closing positions.

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -478,8 +478,7 @@ contract Exchange is
         {
             // check price band after swap
             int256 priceSpreadRatioAfterSwap = _getPriceSpreadRatio(params.baseToken, 0);
-            int256 maxPriceSpreadRatio =
-                IMarketRegistry(_marketRegistry).getMarketMaxPriceSpreadRatio(params.baseToken).toInt256();
+            int256 maxPriceSpreadRatio = marketInfo.maxPriceSpreadRatio.toInt256();
             require(
                 PerpMath.min(priceSpreadRatioBeforeSwap, maxPriceSpreadRatio.neg256()) <= priceSpreadRatioAfterSwap &&
                     priceSpreadRatioAfterSwap <= PerpMath.max(priceSpreadRatioBeforeSwap, maxPriceSpreadRatio),

--- a/contracts/MarketRegistry.sol
+++ b/contracts/MarketRegistry.sol
@@ -159,13 +159,20 @@ contract MarketRegistry is IMarketRegistry, ClearingHouseCallee, MarketRegistryS
     }
 
     /// @inheritdoc IMarketRegistry
+    /// @dev if we didn't set the max spread ratio for the market, we will use the default value
+    function getMarketMaxPriceSpreadRatio(address baseToken) external view override returns (uint24) {
+        return _getMarketMaxPriceSpreadRatio(baseToken);
+    }
+
+    /// @inheritdoc IMarketRegistry
     function getMarketInfo(address baseToken) external view override checkPool(baseToken) returns (MarketInfo memory) {
         return
             MarketInfo({
                 pool: _poolMap[baseToken],
                 exchangeFeeRatio: _exchangeFeeRatioMap[baseToken],
                 uniswapFeeRatio: _uniswapFeeRatioMap[baseToken],
-                insuranceFundFeeRatio: _insuranceFundFeeRatioMap[baseToken]
+                insuranceFundFeeRatio: _insuranceFundFeeRatioMap[baseToken],
+                maxPriceSpreadRatio: _getMarketMaxPriceSpreadRatio(baseToken)
             });
     }
 
@@ -174,9 +181,11 @@ contract MarketRegistry is IMarketRegistry, ClearingHouseCallee, MarketRegistryS
         return _poolMap[baseToken] != address(0);
     }
 
-    /// @inheritdoc IMarketRegistry
-    /// @dev if we didn't set the max spread ratio for the market, we will use the default value
-    function getMarketMaxPriceSpreadRatio(address baseToken) external view override returns (uint24) {
+    //
+    // INTERNAL VIEW
+    //
+
+    function _getMarketMaxPriceSpreadRatio(address baseToken) internal view returns (uint24) {
         uint24 maxSpreadRatio =
             _marketMaxPriceSpreadRatioMap[baseToken] > 0
                 ? _marketMaxPriceSpreadRatioMap[baseToken]

--- a/contracts/interface/IMarketRegistry.sol
+++ b/contracts/interface/IMarketRegistry.sol
@@ -8,6 +8,7 @@ interface IMarketRegistry {
         uint24 exchangeFeeRatio;
         uint24 uniswapFeeRatio;
         uint24 insuranceFundFeeRatio;
+        uint24 maxPriceSpreadRatio;
     }
 
     /// @notice Emitted when a new market is created.

--- a/test/foundry/clearingHouse/ClearingHouse.priceBand.t.sol
+++ b/test/foundry/clearingHouse/ClearingHouse.priceBand.t.sol
@@ -242,8 +242,8 @@ contract ClearingHousePriceBandTest is Setup {
     }
 
     // before in range, after in range
-    // example: before: before: -5%, after -7% (increase negative spread)
-    function test_open_increase_negative_spread_when_before_and_after_is_in_range() public {
+    // example: before: -5%, after -7% (increase negative spread)
+    function test_increase_negative_spread_when_before_and_after_is_in_range() public {
         // open short position => market price < index price
         // before:
         //  - market price: 99.9999999998

--- a/test/foundry/marketRegistry/ILegacyMarketRegistry.sol
+++ b/test/foundry/marketRegistry/ILegacyMarketRegistry.sol
@@ -1,0 +1,15 @@
+pragma solidity 0.7.6;
+pragma abicoder v2;
+
+// this interface is to test backward compatibility of marketRegistry
+interface ILegacyMarketRegistry {
+    struct LegacyMarketInfo {
+        address pool;
+        uint24 exchangeFeeRatio;
+        uint24 uniswapFeeRatio;
+        uint24 insuranceFundFeeRatio;
+        // ignore maxPriceSpreadRatio field
+    }
+
+    function getMarketInfo(address baseToken) external view returns (LegacyMarketInfo memory info);
+}

--- a/test/foundry/marketRegistry/MarketRegistry.t.sol
+++ b/test/foundry/marketRegistry/MarketRegistry.t.sol
@@ -8,6 +8,7 @@ import "../interface/IMarketRegistryEvent.sol";
 import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
 import "@uniswap/v3-core/contracts/interfaces/pool/IUniswapV3PoolState.sol";
 import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+import { ILegacyMarketRegistry } from "./ILegacyMarketRegistry.sol";
 
 contract MarketRegistryAddPoolTest is IMarketRegistryEvent, Setup {
     function setUp() public virtual override {
@@ -245,5 +246,23 @@ contract MarketRegistrySetterTest is IMarketRegistryEvent, Setup {
     function test_getMarketMaxPriceSpreadRatio_when_set() public {
         marketRegistry.setMarketMaxPriceSpreadRatio(address(baseToken), 0.2e6);
         assertEq(uint256(marketRegistry.getMarketMaxPriceSpreadRatio(address(baseToken))), 0.2e6);
+    }
+
+    function test_getMarketInfo() public {
+        IMarketRegistry.MarketInfo memory marketInfo = marketRegistry.getMarketInfo(address(baseToken));
+        assertEq(marketInfo.pool, address(pool));
+        assertEq(uint256(marketInfo.exchangeFeeRatio), _DEFAULT_POOL_FEE);
+        assertEq(uint256(marketInfo.uniswapFeeRatio), _DEFAULT_POOL_FEE);
+        assertEq(uint256(marketInfo.insuranceFundFeeRatio), 0);
+        assertEq(uint256(marketInfo.maxPriceSpreadRatio), 0.1e6);
+    }
+
+    function test_getMarketInfo_legacy_struct() public {
+        ILegacyMarketRegistry.LegacyMarketInfo memory legacyMarketInfo =
+            ILegacyMarketRegistry(address(marketRegistry)).getMarketInfo(address(baseToken));
+        assertEq(legacyMarketInfo.pool, address(pool));
+        assertEq(uint256(legacyMarketInfo.exchangeFeeRatio), _DEFAULT_POOL_FEE);
+        assertEq(uint256(legacyMarketInfo.uniswapFeeRatio), _DEFAULT_POOL_FEE);
+        assertEq(uint256(legacyMarketInfo.insuranceFundFeeRatio), 0);
     }
 }


### PR DESCRIPTION
Added a new field, maxPriceSpreadRatio, to the `IMarketRegistry.MarketInfo` struct. The `MarketRegistry.getMarketInfo` function will now return the maxPriceSpreadRatio value for a market.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204279461893838