### PR TITLE
Preferential fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Add `MarketRegistry.setFeeDiscountRatio()` to set a fee discount ratio to a trader.
+- Add `MarketRegistry.getMarketInfoByTrader()` to get a market info related to a trader.
+- Refine `Orderbook.replaySwap` to retrieve market info from arguments.
 
 ## [2.6.0] - 2023-04-10
 ### Changed

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -425,6 +425,7 @@ contract Exchange is
             IOrderBook(_orderBook).replaySwap(
                 IOrderBook.ReplaySwapParams({
                     baseToken: params.baseToken,
+                    pool: marketInfo.pool,
                     isBaseToQuote: params.isBaseToQuote,
                     amount: signedScaledAmountForReplaySwap,
                     sqrtPriceLimitX96: params.sqrtPriceLimitX96,
@@ -458,6 +459,7 @@ contract Exchange is
             IOrderBook(_orderBook).replaySwap(
                 IOrderBook.ReplaySwapParams({
                     baseToken: params.baseToken,
+                    pool: marketInfo.pool,
                     isBaseToQuote: params.isBaseToQuote,
                     shouldUpdateState: true,
                     amount: signedScaledAmountForReplaySwap,

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -53,12 +53,12 @@ contract Exchange is
     //
 
     struct InternalReplaySwapParams {
-        address trader;
         address baseToken;
         bool isBaseToQuote;
         bool isExactInput;
         uint256 amount;
         uint160 sqrtPriceLimitX96;
+        address trader;
     }
 
     struct InternalSwapResponse {

--- a/contracts/OrderBook.sol
+++ b/contracts/OrderBook.sol
@@ -262,8 +262,6 @@ contract OrderBook is
 
         address pool = IMarketRegistry(_marketRegistry).getPool(params.baseToken);
         bool isExactInput = params.amount > 0;
-        uint24 insuranceFundFeeRatio =
-            IMarketRegistry(_marketRegistry).getMarketInfo(params.baseToken).insuranceFundFeeRatio;
         uint256 fee;
         uint256 insuranceFundFee; // insuranceFundFee = fee * insuranceFundFeeRatio
 
@@ -339,7 +337,7 @@ contract OrderBook is
                 }
 
                 fee += step.fee;
-                uint256 stepInsuranceFundFee = FullMath.mulDivRoundingUp(step.fee, insuranceFundFeeRatio, 1e6);
+                uint256 stepInsuranceFundFee = FullMath.mulDivRoundingUp(step.fee, params.insuranceFundFeeRatio, 1e6);
                 insuranceFundFee += stepInsuranceFundFee;
                 uint256 stepMakerFee = step.fee.sub(stepInsuranceFundFee);
                 swapState.feeGrowthGlobalX128 += FullMath.mulDiv(stepMakerFee, FixedPoint128.Q128, swapState.liquidity);

--- a/contracts/interface/IMarketRegistry.sol
+++ b/contracts/interface/IMarketRegistry.sol
@@ -36,6 +36,11 @@ interface IMarketRegistry {
     /// @param spreadRatio Max market price spread ratio
     event MarketMaxPriceSpreadRatioChanged(address indexed baseToken, uint24 spreadRatio);
 
+    /// @notice Emitted when the trader's fee discount ratio gets updated.
+    /// @param trader The address of the trader
+    /// @param discountRatio Fee discount ratio (percent-off)
+    event FeeDiscountRatioChanged(address indexed trader, uint24 discountRatio);
+
     /// @notice Get the pool address (UNIv3 pool) by given base token address
     /// @param baseToken The address of the base token
     /// @return pool The address of the pool
@@ -57,6 +62,12 @@ interface IMarketRegistry {
     /// @param baseToken The address of the base token
     /// @return info The market info encoded as `MarketInfo`
     function getMarketInfo(address baseToken) external view returns (MarketInfo memory info);
+
+    /// @notice Get the market info by given trader address and base token address
+    /// @param trader The address of the trader
+    /// @param baseToken The address of the base token
+    /// @return info The market info encoded as `MarketInfo`
+    function getMarketInfoByTrader(address trader, address baseToken) external view returns (MarketInfo memory info);
 
     /// @notice Get the quote token address
     /// @return quoteToken The address of the quote token

--- a/contracts/interface/IOrderBook.sol
+++ b/contracts/interface/IOrderBook.sol
@@ -82,7 +82,7 @@ interface IOrderBook {
         returns (RemoveLiquidityResponse memory response);
 
     /// @dev This is the non-view version of `getLiquidityCoefficientInFundingPayment()`,
-    /// only can be called by `ClearingHouse` contract
+    /// only can be called by `Exchange` contract
     /// @param trader The trader address
     /// @param baseToken The base token address
     /// @param fundingGrowthGlobal The funding growth info, detail on `Funding.Growth`
@@ -94,7 +94,7 @@ interface IOrderBook {
     ) external returns (int256 liquidityCoefficientInFundingPayment);
 
     /// @notice Replay the swap and get the swap result (price impact and swap fee),
-    /// only can be called by `ClearingHouse` contract;
+    /// only can be called by `Exchange` contract;
     /// @dev `ReplaySwapResponse.insuranceFundFee = fee * insuranceFundFeeRatio`
     /// @param params ReplaySwap params, detail on `IOrderBook.ReplaySwapParams`
     /// @return response The swap result encoded in `ReplaySwapResponse`

--- a/contracts/interface/IOrderBook.sol
+++ b/contracts/interface/IOrderBook.sol
@@ -41,15 +41,15 @@ interface IOrderBook {
 
     struct ReplaySwapParams {
         address baseToken;
-        address pool;
-        int256 amount;
         bool isBaseToQuote;
         bool shouldUpdateState;
+        int256 amount;
         uint160 sqrtPriceLimitX96;
         uint24 exchangeFeeRatio;
         uint24 uniswapFeeRatio;
-        uint24 insuranceFundFeeRatio;
         Funding.Growth globalFundingGrowth;
+        address pool;
+        uint24 insuranceFundFeeRatio;
     }
 
     /// @param insuranceFundFee = fee * insuranceFundFeeRatio

--- a/contracts/interface/IOrderBook.sol
+++ b/contracts/interface/IOrderBook.sol
@@ -41,12 +41,13 @@ interface IOrderBook {
 
     struct ReplaySwapParams {
         address baseToken;
+        int256 amount;
         bool isBaseToQuote;
         bool shouldUpdateState;
-        int256 amount;
         uint160 sqrtPriceLimitX96;
         uint24 exchangeFeeRatio;
         uint24 uniswapFeeRatio;
+        uint24 insuranceFundFeeRatio;
         Funding.Growth globalFundingGrowth;
     }
 

--- a/contracts/interface/IOrderBook.sol
+++ b/contracts/interface/IOrderBook.sol
@@ -41,6 +41,7 @@ interface IOrderBook {
 
     struct ReplaySwapParams {
         address baseToken;
+        address pool;
         int256 amount;
         bool isBaseToQuote;
         bool shouldUpdateState;

--- a/contracts/storage/MarketRegistryStorage.sol
+++ b/contracts/storage/MarketRegistryStorage.sol
@@ -28,3 +28,9 @@ abstract contract MarketRegistryStorageV2 is MarketRegistryStorageV1 {
     // value: the max price spread ratio of the market
     mapping(address => uint24) internal _marketMaxPriceSpreadRatioMap;
 }
+
+abstract contract MarketRegistryStorageV3 is MarketRegistryStorageV2 {
+    // key: trader
+    // value: discount ratio (percent-off)
+    mapping(address => uint24) internal _feeDiscountRatioMap;
+}

--- a/test/clearingHouse/ClearingHouse.customiseFee.test.ts
+++ b/test/clearingHouse/ClearingHouse.customiseFee.test.ts
@@ -736,6 +736,67 @@ describe("ClearingHouse customized fee", () => {
         })
     })
 
+    describe("change taker's fee discount ratio", async () => {
+        beforeEach(async () => {
+            // set fee ratio to 0.5%
+            await marketRegistry.setFeeRatio(baseToken.address, 20000)
+            await deposit(taker, vault, 1000, collateral)
+
+            await clearingHouse.connect(taker).openPosition({
+                baseToken: baseToken.address,
+                isBaseToQuote: false,
+                isExactInput: true,
+                oppositeAmountBound: 0,
+                amount: parseEther("1"),
+                sqrtPriceLimitX96: 0,
+                deadline: ethers.constants.MaxUint256,
+                referralCode: ethers.constants.HashZero,
+            })
+        })
+
+        it("swap with customized discount", async () => {
+            await marketRegistry.setFeeDiscountRatio(taker.address, 0.1e6)
+
+            // taker swap 1 USD for ? ETH
+            await expect(
+                clearingHouse.connect(taker).openPosition({
+                    baseToken: baseToken.address,
+                    isBaseToQuote: false,
+                    isExactInput: true,
+                    oppositeAmountBound: 0,
+                    amount: parseEther("1"),
+                    sqrtPriceLimitX96: 0,
+                    deadline: ethers.constants.MaxUint256,
+                    referralCode: ethers.constants.HashZero,
+                }),
+            )
+                .to.emit(clearingHouse, "PositionChanged")
+                .withArgs(
+                    taker.address, // trader
+                    baseToken.address, // baseToken
+                    "6485520158501717", // exchangedPositionSize
+                    parseEther("-0.982"), // exchangedPositionNotional = -(1-0.018)
+                    parseEther("0.018"), // fee = 1 * 0.02 * 0.9
+                    parseEther("-2"), // openNotional = -1 + -1
+                    parseEther("0"), // realizedPnl
+                    "974950371043325929393898091208", // sqrtPriceAfterX96
+                )
+
+            const fee = (
+                await clearingHouse.connect(maker).callStatic.removeLiquidity({
+                    baseToken: baseToken.address,
+                    lowerTick: lowerTick,
+                    upperTick: upperTick,
+                    liquidity: 0,
+                    minBase: 0,
+                    minQuote: 0,
+                    deadline: ethers.constants.MaxUint256,
+                })
+            ).fee
+            expect(fee).to.be.closeTo(parseEther("0.038"), 1) // 0.018 + 0.02
+        })
+    })
+
     describe("CH fee with multiple makers", async () => {
         let liquidity1: BigNumber
         let liquidity2: BigNumber

--- a/test/clearingHouse/ClearingHouse.customiseFee.test.ts
+++ b/test/clearingHouse/ClearingHouse.customiseFee.test.ts
@@ -738,7 +738,7 @@ describe("ClearingHouse customized fee", () => {
 
     describe("change taker's fee discount ratio", async () => {
         beforeEach(async () => {
-            // set fee ratio to 0.5%
+            // set fee ratio to 2%
             await marketRegistry.setFeeRatio(baseToken.address, 20000)
             await deposit(taker, vault, 1000, collateral)
 

--- a/test/clearingHouse/ClearingHouse.openPosition.gasEstimation.ts
+++ b/test/clearingHouse/ClearingHouse.openPosition.gasEstimation.ts
@@ -18,7 +18,7 @@ import { mockIndexPrice } from "../shared/utilities"
 import { ClearingHouseFixture, createClearingHouseFixture } from "./fixtures"
 
 // WARNING: this test is outdated and will need to catch up with many upgrades if we'd like to run it
-describe.skip("ClearingHouse.openPosition gasEstimation", () => {
+describe("ClearingHouse.openPosition gasEstimation", () => {
     const [admin, alice, bob, carol] = waffle.provider.getWallets()
     const loadFixture: ReturnType<typeof waffle.createFixtureLoader> = waffle.createFixtureLoader([admin])
     let fixture: ClearingHouseFixture
@@ -84,7 +84,7 @@ describe.skip("ClearingHouse.openPosition gasEstimation", () => {
         })
     })
 
-    it("gas cost for taker", async () => {
+    it.only("gas cost for taker", async () => {
         await collateral.mint(carol.address, parseUnits("1000", collateralDecimals))
         await deposit(carol, vault, 1000, collateral)
         const receipt = await (

--- a/test/clearingHouse/ClearingHouse.openPosition.gasEstimation.ts
+++ b/test/clearingHouse/ClearingHouse.openPosition.gasEstimation.ts
@@ -18,7 +18,7 @@ import { mockIndexPrice } from "../shared/utilities"
 import { ClearingHouseFixture, createClearingHouseFixture } from "./fixtures"
 
 // WARNING: this test is outdated and will need to catch up with many upgrades if we'd like to run it
-describe("ClearingHouse.openPosition gasEstimation", () => {
+describe.skip("ClearingHouse.openPosition gasEstimation", () => {
     const [admin, alice, bob, carol] = waffle.provider.getWallets()
     const loadFixture: ReturnType<typeof waffle.createFixtureLoader> = waffle.createFixtureLoader([admin])
     let fixture: ClearingHouseFixture
@@ -84,7 +84,7 @@ describe("ClearingHouse.openPosition gasEstimation", () => {
         })
     })
 
-    it.only("gas cost for taker", async () => {
+    it("gas cost for taker", async () => {
         await collateral.mint(carol.address, parseUnits("1000", collateralDecimals))
         await deposit(carol, vault, 1000, collateral)
         const receipt = await (

--- a/test/clearingHouse/ClearingHouse.openPosition.gasEstimation.ts
+++ b/test/clearingHouse/ClearingHouse.openPosition.gasEstimation.ts
@@ -84,6 +84,24 @@ describe.skip("ClearingHouse.openPosition gasEstimation", () => {
         })
     })
 
+    it("gas cost for taker", async () => {
+        await collateral.mint(carol.address, parseUnits("1000", collateralDecimals))
+        await deposit(carol, vault, 1000, collateral)
+        const receipt = await (
+            await clearingHouse.connect(carol).openPosition({
+                baseToken: baseToken.address,
+                isBaseToQuote: false,
+                isExactInput: true,
+                oppositeAmountBound: 0,
+                amount: parseEther("0.1"),
+                sqrtPriceLimitX96: 0,
+                deadline: ethers.constants.MaxUint256,
+                referralCode: ethers.constants.HashZero,
+            })
+        ).wait()
+        console.log("gas used: ", receipt.gasUsed.toString())
+    })
+
     it("gas cost for maker", async () => {
         // carol long
         await collateral.mint(carol.address, parseUnits("1000", collateralDecimals))

--- a/test/foundry/interface/IMarketRegistryEvent.sol
+++ b/test/foundry/interface/IMarketRegistryEvent.sol
@@ -7,4 +7,5 @@ interface IMarketRegistryEvent {
     event InsuranceFundFeeRatioChanged(address baseToken, uint24 feeRatio);
     event MaxOrdersPerMarketChanged(uint8 maxOrdersPerMarket);
     event MarketMaxPriceSpreadRatioChanged(address indexed baseToken, uint24 spreadRatio);
+    event FeeDiscountRatioChanged(address indexed trader, uint24 discountRatio);
 }

--- a/test/foundry/marketRegistry/MarketRegistry.t.sol
+++ b/test/foundry/marketRegistry/MarketRegistry.t.sol
@@ -272,11 +272,15 @@ contract MarketRegistrySetterTest is IMarketRegistryEvent, Setup, Constant {
             marketRegistry.getMarketInfoByTrader(bob, address(baseToken));
 
         // 10% off
+        vm.expectEmit(true, true, true, true, address(marketRegistry));
+        emit FeeDiscountRatioChanged(bob, 0.1e6);
         marketRegistry.setFeeDiscountRatio(bob, 0.1e6);
 
         IMarketRegistry.MarketInfo memory marketInfoAfter =
             marketRegistry.getMarketInfoByTrader(bob, address(baseToken));
 
+        vm.expectEmit(true, true, true, true, address(marketRegistry));
+        emit FeeDiscountRatioChanged(bob, 0);
         marketRegistry.setFeeDiscountRatio(bob, 0);
 
         IMarketRegistry.MarketInfo memory marketInfoFinal =

--- a/test/foundry/marketRegistry/MarketRegistry.t.sol
+++ b/test/foundry/marketRegistry/MarketRegistry.t.sol
@@ -263,4 +263,32 @@ contract MarketRegistrySetterTest is IMarketRegistryEvent, Setup, Constant {
         assertEq(uint256(legacyMarketInfo.uniswapFeeRatio), _DEFAULT_POOL_FEE);
         assertEq(uint256(legacyMarketInfo.insuranceFundFeeRatio), 0);
     }
+
+    function test_getMarketInfoByTrader_and_setFeeDiscountRatio() public {
+        address bob = makeAddr("Bob");
+        address alice = makeAddr("Alice");
+
+        IMarketRegistry.MarketInfo memory marketInfoBefore =
+            marketRegistry.getMarketInfoByTrader(bob, address(baseToken));
+
+        // 10% off
+        marketRegistry.setFeeDiscountRatio(bob, 0.1e6);
+
+        IMarketRegistry.MarketInfo memory marketInfoAfter =
+            marketRegistry.getMarketInfoByTrader(bob, address(baseToken));
+
+        marketRegistry.setFeeDiscountRatio(bob, 0);
+
+        IMarketRegistry.MarketInfo memory marketInfoFinal =
+            marketRegistry.getMarketInfoByTrader(bob, address(baseToken));
+
+        assertEq(uint256(marketInfoBefore.exchangeFeeRatio), _DEFAULT_POOL_FEE);
+        assertEq(uint256(marketInfoAfter.exchangeFeeRatio), (uint256(_DEFAULT_POOL_FEE) * 0.9e6) / 1e6);
+        assertEq(uint256(marketInfoFinal.exchangeFeeRatio), _DEFAULT_POOL_FEE);
+
+        IMarketRegistry.MarketInfo memory aliceMarketInfo =
+            marketRegistry.getMarketInfoByTrader(alice, address(baseToken));
+
+        assertEq(uint256(aliceMarketInfo.exchangeFeeRatio), _DEFAULT_POOL_FEE);
+    }
 }


### PR DESCRIPTION
* Added preferential fee related getter and setter (`setFeeDiscountRatio`, `getMarketInfoByTrader`) and update `Exchange.swap` logic
* Gas usage for simply opening up a single position in a market
  - before: 695681
  - after: ~~693924~~ 694081